### PR TITLE
Removed links which are not related to company

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,9 +151,6 @@ list-packages</kbd>).</p>
   <li><a href="http://tuhdo.github.io/c-ide.html#sec-2">C/C++ Development Environment for Emacs</a></li>
   <li><a href="http://bbbscarter.wordpress.com/2013/08/17/c-autocompletion-in-emacs/">C# autocompletion in Emacs</a></li>
   <li><a href="http://lorefnon.me/2014/02/02/configuring-emacs-for-rails.html">Configuring Emacs for Rails</a></li>
-  <li><a href="http://dominik.honnef.co/posts/2013/03/writing_go_in_emacs/">Writing Go in Emacs</a></li>
-  <li><a href="http://bling.github.io/blog/2013/10/27/emacs-as-my-leader-vim-survival-guide/">Emacs as My &lt;Leader&gt;: Vim Survival Guide</a></li>
-  <li><a href="http://hyegar.com/2016/03/02/emacs-for-objc/">Getting Objective-C code completion</a></li>
 </ul>
 
         </section>


### PR DESCRIPTION
- **Getting Objective-C code completion**, 404 - Not Found
- **Emacs as My `<Leader>`: Vim Survival Guide**, the word "company" occurs on the whole page 4 times and there is nothing related to company-mode
- **Writing Go in Emacs**, the word "company" occurs on the whole page 2 times