### PR TITLE
Link to more user-friendly CA explanation page

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@ list-packages</kbd>).</p>
 <h2>Contributing</h2>
 
 <p>Company is subject to the same
-  <a href="http://www.gnu.org/prep/maintain/html_node/Copyright-Papers.html">copyright assignment</a>
+  <a href="https://www.fsf.org/licensing/contributor-faq" target="_blank">copyright assignment</a>
   policy as Emacs itself, org-mode, CEDET and other packages
   in <a href="http://elpa.gnu.org/packages/">GNU ELPA</a>.
 


### PR DESCRIPTION
The `FSF` added `CA FAQ` page a month ago. It is *much* more readable - especially for newbies - than the text written for the maintainers.