### PR TITLE
Revise the list of backends

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,11 +36,10 @@
   and front-ends to retrieve and display completion candidates.</p>
 
 <p>It comes with several back-ends such as <code>Elisp</code>,
-  <code>Clang</code>, <code>Semantic</code>, <code>Eclim</code>,
-  <code>Ropemacs</code>, <code>Ispell</code>, <code>CMake</code>,
-  <code>BBDB</code>, <code>Yasnippet</code>,
-  <code>dabbrev</code>, <code>etags</code>, <code>gtags</code>,
-  <code>files</code>, <code>keywords</code> and a few others.</p>
+  <code>Clang</code>, <code>Semantic</code>, <code>Ispell</code>,
+  <code>CMake</code>, <code>BBDB</code>, <code>Yasnippet</code>,
+  <code>Dabbrev</code>, <code>Etags</code>, <code>Gtags</code>,
+  <code>Files</code>, <code>Keywords</code> and a few others.</p>
 
 <p>The <code>CAPF</code> back-end provides a bridge to the
   standard <a href="https://www.gnu.org/software/emacs/manual/html_node/elisp/Completion-in-Buffers.html"


### PR DESCRIPTION
`Ropemacs` was removed back in 2016 and `TNG` seems to be quite popular.
The order was changed for better-looking output.
