### PR TITLE
Link stylesheet in manual pages

### DIFF
--- a/manual/Backends.html
+++ b/manual/Backends.html
@@ -43,6 +43,7 @@ span:hover a.copiable-anchor {visibility: visible}
 ul.no-bullet {list-style: none}
 -->
 </style>
+<link rel="stylesheet" type="text/css" href="http://company-mode.github.io/stylesheets/stylesheet.css">
 
 
 </head>

--- a/manual/Customization.html
+++ b/manual/Customization.html
@@ -43,6 +43,7 @@ span:hover a.copiable-anchor {visibility: visible}
 ul.no-bullet {list-style: none}
 -->
 </style>
+<link rel="stylesheet" type="text/css" href="http://company-mode.github.io/stylesheets/stylesheet.css">
 
 
 </head>

--- a/manual/Frontends.html
+++ b/manual/Frontends.html
@@ -43,6 +43,7 @@ span:hover a.copiable-anchor {visibility: visible}
 ul.no-bullet {list-style: none}
 -->
 </style>
+<link rel="stylesheet" type="text/css" href="http://company-mode.github.io/stylesheets/stylesheet.css">
 
 
 </head>

--- a/manual/Getting-Started.html
+++ b/manual/Getting-Started.html
@@ -43,6 +43,7 @@ span:hover a.copiable-anchor {visibility: visible}
 ul.no-bullet {list-style: none}
 -->
 </style>
+<link rel="stylesheet" type="text/css" href="http://company-mode.github.io/stylesheets/stylesheet.css">
 
 
 </head>

--- a/manual/Overview.html
+++ b/manual/Overview.html
@@ -43,6 +43,7 @@ span:hover a.copiable-anchor {visibility: visible}
 ul.no-bullet {list-style: none}
 -->
 </style>
+<link rel="stylesheet" type="text/css" href="http://company-mode.github.io/stylesheets/stylesheet.css">
 
 
 </head>

--- a/manual/Troubleshooting.html
+++ b/manual/Troubleshooting.html
@@ -42,6 +42,7 @@ span:hover a.copiable-anchor {visibility: visible}
 ul.no-bullet {list-style: none}
 -->
 </style>
+<link rel="stylesheet" type="text/css" href="http://company-mode.github.io/stylesheets/stylesheet.css">
 
 
 </head>

--- a/manual/index.html
+++ b/manual/index.html
@@ -41,6 +41,7 @@ span:hover a.copiable-anchor {visibility: visible}
 ul.no-bullet {list-style: none}
 -->
 </style>
+<link rel="stylesheet" type="text/css" href="http://company-mode.github.io/stylesheets/stylesheet.css">
 
 
 </head>


### PR DESCRIPTION
The stylesheet wasn't linked in the manual pages, so this commit should fix the look of the manual.