### PR TITLE
User manual: generate latest with Texinfo 7.0

### DIFF
--- a/manual/Backends.html
+++ b/manual/Backends.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
-<!-- Created by GNU Texinfo 6.8, https://www.gnu.org/software/texinfo/ -->
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <!-- This user manual is for Company version 0.9.14snapshot
-(12 August 2022).
+(16 April 2023).
 
-Copyright (C) 2021-2022  Free Software Foundation, Inc.
+Copyright © 2021-2023  Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -27,21 +27,15 @@ any later version published by the Free Software Foundation. -->
 <link href="Frontends.html#Frontends" rel="prev" title="Frontends">
 <style type="text/css">
 <!--
-a.copiable-anchor {visibility: hidden; text-decoration: none; line-height: 0em}
-a.summary-letter {text-decoration: none}
-blockquote.indentedblock {margin-right: 0em}
-div.display {margin-left: 3.2em}
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
 div.example {margin-left: 3.2em}
-kbd {font-style: oblique}
-pre.display {font-family: inherit}
-pre.format {font-family: inherit}
-pre.menu-comment {font-family: serif}
-pre.menu-preformatted {font-family: serif}
-span.nolinebreak {white-space: nowrap}
-span.roman {font-family: initial; font-weight: normal}
-span.sansserif {font-family: sans-serif; font-weight: normal}
-span:hover a.copiable-anchor {visibility: visible}
-ul.no-bullet {list-style: none}
+kbd.kbd {font-style: oblique}
+kbd.key {font-style: normal}
+span.w-nolinebreak-text {white-space: nowrap}
+span:hover a.copiable-link {visibility: visible}
+strong.def-name {font-family: monospace; font-weight: bold; font-size: larger}
+ul.mark-bullet {list-style-type: disc}
+ul.mark-minus {list-style-type: "\2212"}
 -->
 </style>
 <link rel="stylesheet" type="text/css" href="https://company-mode.github.io/stylesheets/stylesheet.css">
@@ -50,98 +44,98 @@ ul.no-bullet {list-style: none}
 </head>
 
 <body lang="en">
-<div class="inner manual"><div class="chapter" id="Backends">
-<div class="header">
+<div class="inner manual"><div class="chapter-level-extent" id="Backends">
+<div class="nav-panel">
 <p>
 Next: <a href="Troubleshooting.html" accesskey="n" rel="next">Troubleshooting</a>, Previous: <a href="Frontends.html#Frontends" accesskey="p" rel="prev">Frontends</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>
 <hr>
-<span id="Backends-1"></span><h2 class="chapter">Backends</h2>
+<h2 class="chapter" id="Backends-1">Backends</h2>
 
-<span id="index-backends"></span>
+<a class="index-entry-id" id="index-backends"></a>
 <p>We can metaphorically say that each backend is like an engine.  (The
 reality is even better since backends are just functions.)  Fueling
 such an engine with a command causes the production of material for
 Company to move further on.  Typically, moving on means outputting
 that material to a user via one or several configured frontends,
-<a href="Frontends.html#Frontends">Frontends</a>.
+<a class="ref" href="Frontends.html#Frontends">Frontends</a>.
 </p>
-<span id="index-company_002dbackends"></span>
+<a class="index-entry-id" id="index-company_002dbackends"></a>
 <p>Just like Company provides a preconfigured list of the enabled
 frontends, it also defines a list of the backends to rely on by
 default.  This list is stored in the user option
-<code><span class="nolinebreak">company-backends</span></code><!-- /@w -->.  The docstring of this variable has been
+<code class="code"><span class="w-nolinebreak-text">company-backends</span></code><!-- /@w -->.  The docstring of this variable has been
 a source of valuable information for years.  That&rsquo;s why we&rsquo;re going to
-stick to a tradition and suggest reading the output of <kbd>C-h v
+stick to a tradition and suggest reading the output of <kbd class="kbd">C-h v
 company-backends</kbd> for insightful details about backends.
 Nevertheless, the fundamental concepts are described in this user
 manual too.
 </p>
 
 <hr>
-<div class="section" id="Backends-Usage-Basics">
-<span id="Backends-Usage-Basics-1"></span><h3 class="section">Backends Usage Basics</h3>
+<div class="section-level-extent" id="Backends-Usage-Basics">
+<h3 class="section" id="Backends-Usage-Basics-1">Backends Usage Basics</h3>
 
-<span id="index-backends-1"></span>
-<span id="index-company_002dbackends-1"></span>
+<a class="index-entry-id" id="index-backends-1"></a>
+<a class="index-entry-id" id="index-company_002dbackends-1"></a>
 <p>One of the significant concepts to understand about Company is that
-the package relies on one backend at a time <a id="DOCF5" href="#FOOT5"><sup>5</sup></a>.  The
+the package relies on one backend at a time <a class="footnote" id="DOCF5" href="#FOOT5"><sup>5</sup></a>.  The
 backends are invoked one by one, in the sequential order of the items
-on the <code>company-backends</code> list.
+on the <code class="code">company-backends</code> list.
 </p>
-<span id="index-active-backend"></span>
-<span id="index-backend-2"></span>
-<span id="index-company_002ddiag"></span>
+<a class="index-entry-id" id="index-active-backend"></a>
+<a class="index-entry-id" id="index-backend-2"></a>
+<a class="index-entry-id" id="index-company_002ddiag"></a>
 <p>The name of the currently active backend is shown in the mode line and
-in the output of the command <kbd>M-x company-diag</kbd>.
+in the output of the command <kbd class="kbd">M-x company-diag</kbd>.
 </p>
-<span id="index-next-backend"></span>
-<span id="index-backend-3"></span>
-<span id="index-company_002dother_002dbackend"></span>
+<a class="index-entry-id" id="index-next-backend"></a>
+<a class="index-entry-id" id="index-backend-3"></a>
+<a class="index-entry-id" id="index-company_002dother_002dbackend"></a>
 <p>In most cases (mainly to exclude false-positive results), the next
 backend is not invoked automatically.  For the purpose of invoking the
-next backend, use the command <kbd><span class="nolinebreak">company-other-backend</span></kbd><!-- /@w -->: either
-by calling it with <kbd>M-x</kbd> or by binding the command to the keys of
+next backend, use the command <kbd class="kbd"><span class="w-nolinebreak-text">company-other-backend</span></kbd><!-- /@w -->: either
+by calling it with <kbd class="kbd">M-x</kbd> or by binding the command to the keys of
 your choice, such as:
 </p>
 <div class="example lisp">
-<pre class="lisp">(global-set-key (kbd &quot;C-c C-/&quot;) #'company-other-backend)
+<pre class="lisp-preformatted">(global-set-key (kbd &quot;C-c C-/&quot;) #'company-other-backend)
 </pre></div>
 
-<span id="index-company_002dbegin_002dbackend"></span>
+<a class="index-entry-id" id="index-company_002dbegin_002dbackend"></a>
 <p>It is also possible to specifically start a backend with the command
-<kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">company-begin-backend</span></kbd><!-- /@w --> or by calling a backend by its
-name, for instance: <kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">company-capf</span></kbd><!-- /@w -->.  As usual for Emacs,
+<kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">company-begin-backend</span></kbd><!-- /@w --> or by calling a backend by its
+name, for instance: <kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">company-capf</span></kbd><!-- /@w -->.  As usual for Emacs,
 such backends calls can be assigned to key bindings, for example:
 </p>
 <div class="example lisp">
-<pre class="lisp">(global-set-key (kbd &quot;C-c y&quot;) 'company-yasnippet)
+<pre class="lisp-preformatted">(global-set-key (kbd &quot;C-c y&quot;) 'company-yasnippet)
 </pre></div>
 
 <hr>
 </div>
-<div class="section" id="Grouped-Backends">
-<span id="Grouped-Backends-1"></span><h3 class="section">Grouped Backends</h3>
+<div class="section-level-extent" id="Grouped-Backends">
+<h3 class="section" id="Grouped-Backends-1">Grouped Backends</h3>
 
-<span id="index-grouped-backends"></span>
-<span id="index-backends-2"></span>
-<span id="index-company_002dbackends-2"></span>
+<a class="index-entry-id" id="index-grouped-backends"></a>
+<a class="index-entry-id" id="index-backends-2"></a>
+<a class="index-entry-id" id="index-company_002dbackends-2"></a>
 <p>In many cases, it can be desirable to receive candidates from several
 backends simultaneously.  This can be achieved by configuring
-<em>grouped backends</em>: a sub-list of backends in the
-<code>company-backends</code> list, that is handled specifically by Company.
+<em class="dfn">grouped backends</em>: a sub-list of backends in the
+<code class="code">company-backends</code> list, that is handled specifically by Company.
 </p>
 <p>The most important part of this handling is the merge of the
 completion candidates from the grouped backends.  (But only from the
-backends that return the same <em>prefix</em> value, see <code>C-h v
+backends that return the same <em class="emph">prefix</em> value, see <code class="code">C-h v
 company-backends</code> for more details.)
 </p>
 <p>To keep the candidates organized in accordance with the grouped
-backends order, add the keyword <code>:separate</code> to the list of the
+backends order, add the keyword <code class="code">:separate</code> to the list of the
 grouped backends.  The following example illustrates this.
 </p>
 <div class="example lisp">
-<pre class="lisp">(defun my-text-mode-hook ()
+<pre class="lisp-preformatted">(defun my-text-mode-hook ()
   (setq-local company-backends
               '((company-dabbrev company-ispell :separate)
                 company-files)))
@@ -149,27 +143,27 @@ grouped backends.  The following example illustrates this.
 (add-hook 'text-mode-hook #'my-text-mode-hook)
 </pre></div>
 
-<p>Another keyword <code>:with</code> helps to make sure the results from
-major/minor mode agnostic backends (such as <em>company-yasnippet</em>,
-<em>company-dabbrev-code</em>) are returned without preventing results
-from context-aware backends (such as <em>company-capf</em> or
-<em>company-clang</em>).  For this feature to work, put backends
+<p>Another keyword <code class="code">:with</code> helps to make sure the results from
+major/minor mode agnostic backends (such as <em class="emph">company-yasnippet</em>,
+<em class="emph">company-dabbrev-code</em>) are returned without preventing results
+from context-aware backends (such as <em class="emph">company-capf</em> or
+<em class="emph">company-clang</em>).  For this feature to work, put backends
 dependent on a mode at the beginning of the grouped backends list,
-then put a keyword <code>:with</code>, and only then put context agnostic
+then put a keyword <code class="code">:with</code>, and only then put context agnostic
 backend(s), as shown in the following concise example:
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-backends '((company-capf :with company-yasnippet)))
+<pre class="lisp-preformatted">(setq company-backends '((company-capf :with company-yasnippet)))
 </pre></div>
 
 <hr>
 </div>
-<div class="section" id="Package-Backends">
-<span id="Package-Backends-1"></span><h3 class="section">Package Backends</h3>
+<div class="section-level-extent" id="Package-Backends">
+<h3 class="section" id="Package-Backends-1">Package Backends</h3>
 
-<span id="index-package-backends"></span>
-<span id="index-bundled-backends"></span>
-<span id="index-backends-3"></span>
+<a class="index-entry-id" id="index-package-backends"></a>
+<a class="index-entry-id" id="index-bundled-backends"></a>
+<a class="index-entry-id" id="index-backends-3"></a>
 <p>The following sections give a short overview of the commonly used
 backends bundled with Company.  Each section is devoted to one of the
 roughly outlined groups of the backends.
@@ -179,128 +173,128 @@ these options are introduced below.  For those who would like to fetch
 the full list of a backend&rsquo;s user options, we suggest doing one of the
 following:
 </p>
-<ul>
-<li> Execute command <kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">customize-group</span>&nbsp;<span class="key">RET</span>&nbsp;<span class="nolinebreak">&lt;backend-name&gt;</span></kbd><!-- /@w -->.
+<ul class="itemize mark-bullet">
+<li>Execute command <kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">customize-group</span>&nbsp;<kbd class="key">RET</kbd>&nbsp;<span class="w-nolinebreak-text">&lt;backend-name&gt;</span></kbd><!-- /@w -->.
 
-</li><li> Open the source file of the backend and run <kbd><span class="nolinebreak">M-x</span>&nbsp;occur&nbsp;<span class="key">RET</span>&nbsp;^(defcustom</kbd><!-- /@w -->.
+</li><li>Open the source file of the backend and run <kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;occur&nbsp;<kbd class="key">RET</kbd>&nbsp;^(defcustom</kbd><!-- /@w -->.
 
-<ul class="no-bullet">
-<li>- Optionally, search for the matches with <kbd><span class="nolinebreak">M-x</span>&nbsp;isearch&nbsp;<span class="key">RET</span>&nbsp;(defcustom</kbd><!-- /@w -->.
+<ul class="itemize mark-minus">
+<li>Optionally, search for the matches with <kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;isearch&nbsp;<kbd class="key">RET</kbd>&nbsp;(defcustom</kbd><!-- /@w -->.
 </li></ul>
 
 </li></ul>
 
 
 <hr>
-<div class="subsection" id="Code-Completion">
-<span id="Code-Completion-1"></span><h4 class="subsection">Code Completion</h4>
+<div class="subsection-level-extent" id="Code-Completion">
+<h4 class="subsection" id="Code-Completion-1">Code Completion</h4>
 
-<dl class="def">
-<dt id="index-company_002dcapf"><span class="category">Function: </span><span><strong>company-capf</strong><a href='#index-company_002dcapf' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dcapf"><span class="category-def">Function: </span><span><strong class="def-name">company-capf</strong><a class="copiable-link" href='#index-company_002dcapf'> &para;</a></span></dt>
 <dd><p>In the Emacs&rsquo;s world, the current tendency is to have the completion
-logic provided by <code><span class="nolinebreak">completion-at-point-functions</span></code><!-- /@w -->
-(<acronym>CAPF</acronym>) implementations.  [Among the other things, this is
+logic provided by <code class="code"><span class="w-nolinebreak-text">completion-at-point-functions</span></code><!-- /@w -->
+(<abbr class="acronym">CAPF</abbr>) implementations.  [Among the other things, this is
 what the popular packages that support language server protocol
-(<acronym>LSP</acronym>) also rely on.]
+(<abbr class="acronym">LSP</abbr>) also rely on.]
 </p>
-<p>Since <em>company-capf</em> works as a bridge to the standard
-<acronym>CAPF</acronym> facility, it is probably the most often used and
+<p>Since <em class="emph">company-capf</em> works as a bridge to the standard
+<abbr class="acronym">CAPF</abbr> facility, it is probably the most often used and
 recommended backend nowadays, including for Emacs Lisp coding.
 </p>
 <p>Just to illustrate, the following minimal backends setup
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-backends '((company-capf company-dabbrev-code)))
+<pre class="lisp-preformatted">(setq company-backends '((company-capf company-dabbrev-code)))
 </pre></div>
 
 <p>might cover a large number of basic use cases, especially so in major
-modes that have <acronym>CAPF</acronym> support implemented.
+modes that have <abbr class="acronym">CAPF</abbr> support implemented.
 </p>
-<p>For more details on <acronym>CAPF</acronym>, <a data-manual="elisp" href="https://www.gnu.org/software/emacs/manual/html_node/elisp/Completion-in-Buffers.html#Completion-in-Buffers">(elisp)Completion in Buffers</a>.
+<p>For more details on <abbr class="acronym">CAPF</abbr>, <a data-manual="elisp" href="https://www.gnu.org/software/emacs/manual/html_node/elisp/Completion-in-Buffers.html#Completion-in-Buffers">(elisp)Completion in Buffers</a>.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002ddabbrev_002dcode"><span class="category">Function: </span><span><strong>company-dabbrev-code</strong><a href='#index-company_002ddabbrev_002dcode' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002ddabbrev_002dcode"><span class="category-def">Function: </span><span><strong class="def-name">company-dabbrev-code</strong><a class="copiable-link" href='#index-company_002ddabbrev_002dcode'> &para;</a></span></dt>
 <dd><p>This backend works similarly to the built-in Emacs package
-<em>dabbrev</em>, searching for completion candidates inside the
+<em class="emph">dabbrev</em>, searching for completion candidates inside the
 contents of the open buffer(s).  Internally, its based on the backend
-<em>company-dabbrev</em> (see <a href="#Text-Completion">Text Completion</a>).
+<em class="emph">company-dabbrev</em> (see <a class="pxref" href="#Text-Completion">Text Completion</a>).
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dkeywords"><span class="category">Function: </span><span><strong>company-keywords</strong><a href='#index-company_002dkeywords' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dkeywords"><span class="category-def">Function: </span><span><strong class="def-name">company-keywords</strong><a class="copiable-link" href='#index-company_002dkeywords'> &para;</a></span></dt>
 <dd><p>This backend provides completions for many of the widely spread
-programming languages <em>keywords</em>: words bearing specific meaning
+programming languages <em class="emph">keywords</em>: words bearing specific meaning
 in a language.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dclang"><span class="category">Function: </span><span><strong>company-clang</strong><a href='#index-company_002dclang' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dclang"><span class="category-def">Function: </span><span><strong class="def-name">company-clang</strong><a class="copiable-link" href='#index-company_002dclang'> &para;</a></span></dt>
 <dd><p>As the name suggests, use this backend to get completions from
-<em>Clang</em> compiler; that is, for the languages in the <em>C</em>
-language family: <em>C</em>, <em>C++</em>, <em>Objective-C</em>.
+<em class="emph">Clang</em> compiler; that is, for the languages in the <em class="emph">C</em>
+language family: <em class="emph">C</em>, <em class="emph">C++</em>, <em class="emph">Objective-C</em>.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dsemantic"><span class="category">Function: </span><span><strong>company-semantic</strong><a href='#index-company_002dsemantic' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dsemantic"><span class="category-def">Function: </span><span><strong class="def-name">company-semantic</strong><a class="copiable-link" href='#index-company_002dsemantic'> &para;</a></span></dt>
 <dd><p>This backend relies on a built-in Emacs package that provides
 language-aware editing commands based on source code parsers,
-<a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Semantic.html#Semantic">(emacs)Semantic</a>.  Having enabled <em>semantic-mode</em> makes it
-to be used by the <acronym>CAPF</acronym> mechanism (see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Symbol-Completion.html#Symbol-Completion">(emacs)Symbol
+<a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Semantic.html#Semantic">(emacs)Semantic</a>.  Having enabled <em class="emph">semantic-mode</em> makes it
+to be used by the <abbr class="acronym">CAPF</abbr> mechanism (see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Symbol-Completion.html#Symbol-Completion">(emacs)Symbol
 Completion</a>), hence a user may consider enabling
-<em>company-capf</em> backend instead.
+<em class="emph">company-capf</em> backend instead.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002detags"><span class="category">Function: </span><span><strong>company-etags</strong><a href='#index-company_002detags' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>This backend works on top of a built-in Emacs package <em>etags</em>,
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002detags"><span class="category-def">Function: </span><span><strong class="def-name">company-etags</strong><a class="copiable-link" href='#index-company_002detags'> &para;</a></span></dt>
+<dd><p>This backend works on top of a built-in Emacs package <em class="emph">etags</em>,
 <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Tags-Tables.html#Tags-Tables">(emacs)Tags Tables</a>.  Similarly to aforementioned
-<em>Semantic</em> usage, tags-based completions now are a part of the
-Emacs&rsquo; <acronym>CAPF</acronym> facility, therefore a user may consider
-switching to <em>company-capf</em> backend.
+<em class="emph">Semantic</em> usage, tags-based completions now are a part of the
+Emacs&rsquo; <abbr class="acronym">CAPF</abbr> facility, therefore a user may consider
+switching to <em class="emph">company-capf</em> backend.
 </p></dd></dl>
 
 <hr>
 </div>
-<div class="subsection" id="Text-Completion">
-<span id="Text-Completion-1"></span><h4 class="subsection">Text Completion</h4>
+<div class="subsection-level-extent" id="Text-Completion">
+<h4 class="subsection" id="Text-Completion-1">Text Completion</h4>
 
-<dl class="def">
-<dt id="index-company_002ddabbrev"><span class="category">Function: </span><span><strong>company-dabbrev</strong><a href='#index-company_002ddabbrev' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002ddabbrev"><span class="category-def">Function: </span><span><strong class="def-name">company-dabbrev</strong><a class="copiable-link" href='#index-company_002ddabbrev'> &para;</a></span></dt>
 <dd><p>This backend works similarly to the built-in Emacs package
-<em>dabbrev</em>, searching for completion candidates inside the
+<em class="emph">dabbrev</em>, searching for completion candidates inside the
 contents of the open buffer(s).  It is one of the often used backends,
 and it has several interesting options for configuration.  Let&rsquo;s
 review a few of them.
 </p>
-<dl class="def">
-<dt id="index-company_002ddabbrev_002dminimum_002dlength"><span class="category">User Option: </span><span><strong>company-dabbrev-minimum-length</strong><a href='#index-company_002ddabbrev_002dminimum_002dlength' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002ddabbrev_002dminimum_002dlength"><span class="category-def">User Option: </span><span><strong class="def-name">company-dabbrev-minimum-length</strong><a class="copiable-link" href='#index-company_002ddabbrev_002dminimum_002dlength'> &para;</a></span></dt>
 <dd><p>This option sets the minimum length of a completion candidate to
-collect from the text.  The default value of &lsquo;<samp>4</samp>&rsquo; is intended to
+collect from the text.  The default value of &lsquo;<samp class="samp">4</samp>&rsquo; is intended to
 prevent potential performance issues.  But in many scenarios, it may
 be acceptable to lower this value.  Note that this option also affects
-the behavior of the <em>company-dabbrev-code</em> backend.
+the behavior of the <em class="emph">company-dabbrev-code</em> backend.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-dabbrev-minimum-length 2)
+<pre class="lisp-preformatted">(setq company-dabbrev-minimum-length 2)
 </pre></div>
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002ddabbrev_002dother_002dbuffers"><span class="category">User Option: </span><span><strong>company-dabbrev-other-buffers</strong><a href='#index-company_002ddabbrev_002dother_002dbuffers' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>By default, <em>company-dabbrev</em> collects completion candidates from
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002ddabbrev_002dother_002dbuffers"><span class="category-def">User Option: </span><span><strong class="def-name">company-dabbrev-other-buffers</strong><a class="copiable-link" href='#index-company_002ddabbrev_002dother_002dbuffers'> &para;</a></span></dt>
+<dd><p>By default, <em class="emph">company-dabbrev</em> collects completion candidates from
 all not ignored buffers (see more on that below).  This behavior can
 be changed to collecting candidates from the current buffer only (by
-setting the value to &lsquo;<samp>nil</samp>&rsquo;) or from the buffers with the same
+setting the value to &lsquo;<samp class="samp">nil</samp>&rsquo;) or from the buffers with the same
 major mode:
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-dabbrev-other-buffers t)
+<pre class="lisp-preformatted">(setq company-dabbrev-other-buffers t)
 </pre></div>
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002ddabbrev_002dignore_002dbuffers"><span class="category">User Option: </span><span><strong>company-dabbrev-ignore-buffers</strong><a href='#index-company_002ddabbrev_002dignore_002dbuffers' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002ddabbrev_002dignore_002dbuffers"><span class="category-def">User Option: </span><span><strong class="def-name">company-dabbrev-ignore-buffers</strong><a class="copiable-link" href='#index-company_002ddabbrev_002dignore_002dbuffers'> &para;</a></span></dt>
 <dd><p>The value of this option should be a regexp or a predicate function
 that can be used to match a buffer name.  The matched buffers are
 omitted from the search for completion candidates.
@@ -308,64 +302,64 @@ omitted from the search for completion candidates.
 
 <p>The last two options described here relate to handling uppercase and
 lowercase letters in completion candidates.  The illustrative examples
-given below can be reproduced in the &lsquo;<samp>*scratch*</samp>&rsquo; buffer, with the
-word &lsquo;<samp>Enjoy</samp>&rsquo; typed in, and with this initial setup:
+given below can be reproduced in the &lsquo;<samp class="samp">*scratch*</samp>&rsquo; buffer, with the
+word &lsquo;<samp class="samp">Enjoy</samp>&rsquo; typed in, and with this initial setup:
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq-local company-backends '(company-dabbrev)
+<pre class="lisp-preformatted">(setq-local company-backends '(company-dabbrev)
             company-dabbrev-other-buffers nil
             company-dabbrev-ignore-case nil
             company-dabbrev-downcase nil)
 </pre></div>
 
-<dl class="def">
-<dt id="index-company_002ddabbrev_002dignore_002dcase"><span class="category">User Option: </span><span><strong>company-dabbrev-ignore-case</strong><a href='#index-company_002ddabbrev_002dignore_002dcase' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002ddabbrev_002dignore_002dcase"><span class="category-def">User Option: </span><span><strong class="def-name">company-dabbrev-ignore-case</strong><a class="copiable-link" href='#index-company_002ddabbrev_002dignore_002dcase'> &para;</a></span></dt>
 <dd><p>This user option controls whether the case is ignored when collecting
-completion candidates.  When the option is set to <code>nil</code>,
-&lsquo;<samp>Enjoy</samp>&rsquo; is suggested as a completion candidate for the typed
-&lsquo;<samp>Enj</samp>&rsquo; letters, but not for &lsquo;<samp>enj</samp>&rsquo;.  When the option is set to
-<code>t</code>, &lsquo;<samp>Enjoy</samp>&rsquo; is suggested as a candidate for both &lsquo;<samp>Enj</samp>&rsquo;
-and &lsquo;<samp>enj</samp>&rsquo; input; note that &lsquo;<samp>enj</samp>&rsquo; prefix is &ldquo;overwritten&rdquo;
-by completing with the &lsquo;<samp>Enjoy</samp>&rsquo; candidate.  The third, default,
+completion candidates.  When the option is set to <code class="code">nil</code>,
+&lsquo;<samp class="samp">Enjoy</samp>&rsquo; is suggested as a completion candidate for the typed
+&lsquo;<samp class="samp">Enj</samp>&rsquo; letters, but not for &lsquo;<samp class="samp">enj</samp>&rsquo;.  When the option is set to
+<code class="code">t</code>, &lsquo;<samp class="samp">Enjoy</samp>&rsquo; is suggested as a candidate for both &lsquo;<samp class="samp">Enj</samp>&rsquo;
+and &lsquo;<samp class="samp">enj</samp>&rsquo; input; note that &lsquo;<samp class="samp">enj</samp>&rsquo; prefix is &ldquo;overwritten&rdquo;
+by completing with the &lsquo;<samp class="samp">Enjoy</samp>&rsquo; candidate.  The third, default,
 type of behavior solves this issue, keeping the case of the typed
 prefix (and still collecting candidates case-insensitively):
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-dabbrev-ignore-case 'keep-prefix)
+<pre class="lisp-preformatted">(setq company-dabbrev-ignore-case 'keep-prefix)
 </pre></div>
 
-<p>Now we can type &lsquo;<samp>enj</samp>&rsquo;, complete it with the suggested
-&lsquo;<samp>Enjoy</samp>&rsquo;, and <em>enjoy</em> the result.
+<p>Now we can type &lsquo;<samp class="samp">enj</samp>&rsquo;, complete it with the suggested
+&lsquo;<samp class="samp">Enjoy</samp>&rsquo;, and <em class="emph">enjoy</em> the result.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002ddabbrev_002ddowncase"><span class="category">User Option: </span><span><strong>company-dabbrev-downcase</strong><a href='#index-company_002ddabbrev_002ddowncase' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002ddabbrev_002ddowncase"><span class="category-def">User Option: </span><span><strong class="def-name">company-dabbrev-downcase</strong><a class="copiable-link" href='#index-company_002ddabbrev_002ddowncase'> &para;</a></span></dt>
 <dd><p>This user option controls whether completion candidates are down-cased
-before their display.  When the option is set to <code>nil</code>, no
+before their display.  When the option is set to <code class="code">nil</code>, no
 transformation is performed; in the environment described above,
-typing &lsquo;<samp>Enj</samp>&rsquo; results in the candidate &lsquo;<samp>Enjoy</samp>&rsquo; being
-suggested.  When the option is set to <code>t</code>, the down-cased
-candidate &lsquo;<samp>enjoy</samp>&rsquo; is suggested.  By default, this option is set
-to <code>case-replace</code>, meaning taking a value of the Emacs&rsquo;s variable
-<code>case-replace</code> (<code>t</code> is the current default).
+typing &lsquo;<samp class="samp">Enj</samp>&rsquo; results in the candidate &lsquo;<samp class="samp">Enjoy</samp>&rsquo; being
+suggested.  When the option is set to <code class="code">t</code>, the down-cased
+candidate &lsquo;<samp class="samp">enjoy</samp>&rsquo; is suggested.  By default, this option is set
+to <code class="code">case-replace</code>, meaning taking a value of the Emacs&rsquo;s variable
+<code class="code">case-replace</code> (<code class="code">t</code> is the current default).
 </p></dd></dl>
 
 </dd></dl>
 
 <br>
-<dl class="def">
-<dt id="index-company_002dispell"><span class="category">Function: </span><span><strong>company-ispell</strong><a href='#index-company_002dispell' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>This backend returns completion candidates collected by <em>Ispell</em>,
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dispell"><span class="category-def">Function: </span><span><strong class="def-name">company-ispell</strong><a class="copiable-link" href='#index-company_002dispell'> &para;</a></span></dt>
+<dd><p>This backend returns completion candidates collected by <em class="emph">Ispell</em>,
 a built-in Emacs package that performs spell-checking.
 See <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Spelling.html#Spelling">(emacs)Checking and Correcting Spelling</a>.  Note that
-<em>Ispell</em> uses only one dictionary at a time (combining several
+<em class="emph">Ispell</em> uses only one dictionary at a time (combining several
 dictionaries into one file is an accepted practice).  By default,
-<em>company-ispell</em> suggests candidates from a dictionary specified
-by the Emacs&rsquo;s setting <code>ispell-complete-word-dict</code>.
+<em class="emph">company-ispell</em> suggests candidates from a dictionary specified
+by the Emacs&rsquo;s setting <code class="code">ispell-complete-word-dict</code>.
 </p>
-<dl class="def">
-<dt id="index-company_002dispell_002ddictionary"><span class="category">User Option: </span><span><strong>company-ispell-dictionary</strong><a href='#index-company_002dispell_002ddictionary' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>Optionally, set a file path for <em>company-ispell</em> to use another
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dispell_002ddictionary"><span class="category-def">User Option: </span><span><strong class="def-name">company-ispell-dictionary</strong><a class="copiable-link" href='#index-company_002dispell_002ddictionary'> &para;</a></span></dt>
+<dd><p>Optionally, set a file path for <em class="emph">company-ispell</em> to use another
 dictionary.
 </p></dd></dl>
 
@@ -373,39 +367,39 @@ dictionary.
 
 <hr>
 </div>
-<div class="subsection" id="File-Name-Completion">
-<span id="File-Name-Completion-1"></span><h4 class="subsection">File Name Completion</h4>
+<div class="subsection-level-extent" id="File-Name-Completion">
+<h4 class="subsection" id="File-Name-Completion-1">File Name Completion</h4>
 
-<dl class="def">
-<dt id="index-company_002dfiles"><span class="category">Function: </span><span><strong>company-files</strong><a href='#index-company_002dfiles' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dfiles"><span class="category-def">Function: </span><span><strong class="def-name">company-files</strong><a class="copiable-link" href='#index-company_002dfiles'> &para;</a></span></dt>
 <dd><p>This backend can be used to retrieve completion candidates for the
 absolute and relative paths in the directory structure of an operating
-system.  The behavior of the <em>company-files</em> backend can be
+system.  The behavior of the <em class="emph">company-files</em> backend can be
 adjusted with the two user options.
 </p>
-<dl class="def">
-<dt id="index-company_002dfiles_002dexclusions"><span class="category">User Option: </span><span><strong>company-files-exclusions</strong><a href='#index-company_002dfiles_002dexclusions' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dfiles_002dexclusions"><span class="category-def">User Option: </span><span><strong class="def-name">company-files-exclusions</strong><a class="copiable-link" href='#index-company_002dfiles_002dexclusions'> &para;</a></span></dt>
 <dd><p>It may be desirable to exclude directories or files from the list of
 suggested completion candidates.  For example, someone&rsquo;s setup might
 look this way:
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-files-exclusions '(&quot;.git/&quot; &quot;.DS_Store&quot;))
+<pre class="lisp-preformatted">(setq company-files-exclusions '(&quot;.git/&quot; &quot;.DS_Store&quot;))
 </pre></div>
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dfiles_002dchop_002dtrailing_002dslash"><span class="category">User Option: </span><span><strong>company-files-chop-trailing-slash</strong><a href='#index-company_002dfiles_002dchop_002dtrailing_002dslash' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dfiles_002dchop_002dtrailing_002dslash"><span class="category-def">User Option: </span><span><strong class="def-name">company-files-chop-trailing-slash</strong><a class="copiable-link" href='#index-company_002dfiles_002dchop_002dtrailing_002dslash'> &para;</a></span></dt>
 <dd><p>This setting is enabled by default, which results in stripping off a
 trailing slash from an inserted directory name.  On typing a trailing
 slash, the process of completion gets started again, from inside the
 just inserted directory.
 </p>
-<p>Setting <code><span class="nolinebreak">company-files-chop-trailing-slash</span></code><!-- /@w --> to <code>nil</code>
+<p>Setting <code class="code"><span class="w-nolinebreak-text">company-files-chop-trailing-slash</span></code><!-- /@w --> to <code class="code">nil</code>
 makes directory names to be inserted as is, with a trailing slash.  In
 this case, the completion process can be continued, for example,
-either by explicitly calling <em>company-files</em> backend
-(see&nbsp;<a href="#Backends-Usage-Basics">Backends Usage Basics</a>)<!-- /@w --> or by starting typing a name of a
+either by explicitly calling <em class="emph">company-files</em> backend
+(see <a class="pxref" href="#Backends-Usage-Basics">Backends Usage Basics</a>) or by starting typing a name of a
 file/directory known to be located under the inserted directory.
 </p></dd></dl>
 
@@ -413,97 +407,97 @@ file/directory known to be located under the inserted directory.
 
 <hr>
 </div>
-<div class="subsection" id="Template-Expansion">
-<span id="Template-Expansion-1"></span><h4 class="subsection">Template Expansion</h4>
+<div class="subsection-level-extent" id="Template-Expansion">
+<h4 class="subsection" id="Template-Expansion-1">Template Expansion</h4>
 
-<span id="index-template"></span>
-<span id="index-expansion"></span>
-<span id="index-snippet"></span>
-<span id="index-abbrev"></span>
-<dl class="def">
-<dt id="index-company_002dabbrev"><span class="category">Function: </span><span><strong>company-abbrev</strong><a href='#index-company_002dabbrev' class='copiable-anchor'> &para;</a></span></dt>
+<a class="index-entry-id" id="index-template"></a>
+<a class="index-entry-id" id="index-expansion"></a>
+<a class="index-entry-id" id="index-snippet"></a>
+<a class="index-entry-id" id="index-abbrev"></a>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dabbrev"><span class="category-def">Function: </span><span><strong class="def-name">company-abbrev</strong><a class="copiable-link" href='#index-company_002dabbrev'> &para;</a></span></dt>
 <dd><p>This is a completion backend for a built-in word abbreviation mode
 (see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Abbrevs.html#Abbrevs">(emacs)Abbrevs</a>), that allows completing abbreviations with
 their expansions.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtempo"><span class="category">Function: </span><span><strong>company-tempo</strong><a href='#index-company_002dtempo' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dtempo"><span class="category-def">Function: </span><span><strong class="def-name">company-tempo</strong><a class="copiable-link" href='#index-company_002dtempo'> &para;</a></span></dt>
 <dd><p>A backend for users of
-<a href="https://www.lysator.liu.se/~davidk/elisp/">Tempo</a>, one more
+<a class="uref" href="https://www.lysator.liu.se/~davidk/elisp/">Tempo</a>, one more
 built-in Emacs package for creating and inserting (expanding)
 templates.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dyasnippet"><span class="category">Function: </span><span><strong>company-yasnippet</strong><a href='#index-company_002dyasnippet' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dyasnippet"><span class="category-def">Function: </span><span><strong class="def-name">company-yasnippet</strong><a class="copiable-link" href='#index-company_002dyasnippet'> &para;</a></span></dt>
 <dd><p>Used as a completion backend for the popular third-party template
-system <a href="https://github.com/joaotavora/yasnippet">YASnippet</a>.
+system <a class="uref" href="https://github.com/joaotavora/yasnippet">YASnippet</a>.
 </p></dd></dl>
 
 <hr>
 </div>
 </div>
-<div class="section" id="Candidates-Post_002dProcessing">
-<span id="Candidates-Post_002dProcessing-1"></span><h3 class="section">Candidates Post-Processing</h3>
+<div class="section-level-extent" id="Candidates-Post_002dProcessing">
+<h3 class="section" id="Candidates-Post_002dProcessing-1">Candidates Post-Processing</h3>
 
-<span id="index-sort"></span>
-<span id="index-duplicate"></span>
-<span id="index-company_002dtransformers"></span>
+<a class="index-entry-id" id="index-sort"></a>
+<a class="index-entry-id" id="index-duplicate"></a>
+<a class="index-entry-id" id="index-company_002dtransformers"></a>
 <p>A list of completion candidates, supplied by a backend, can be
 additionally manipulated (reorganized, reduced, sorted, etc) before
 its output.  This is done by adding a processing function name to the
-user option <code>company-transformers</code> list, for example:
+user option <code class="code">company-transformers</code> list, for example:
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-transformers '(delete-consecutive-dups
+<pre class="lisp-preformatted">(setq company-transformers '(delete-consecutive-dups
                              company-sort-by-occurrence))
 </pre></div>
 
 <p>Company is bundled with several such transformer functions.  They are
 listed below.
 </p>
-<dl class="def">
-<dt id="index-company_002dsort_002dby_002doccurrence"><span class="category">Function: </span><span><strong>company-sort-by-occurrence</strong><a href='#index-company_002dsort_002dby_002doccurrence' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>Sorts candidates using <code>company-occurrence-weight-function</code>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dsort_002dby_002doccurrence"><span class="category-def">Function: </span><span><strong class="def-name">company-sort-by-occurrence</strong><a class="copiable-link" href='#index-company_002dsort_002dby_002doccurrence'> &para;</a></span></dt>
+<dd><p>Sorts candidates using <code class="code">company-occurrence-weight-function</code>
 algorithm.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002doccurrence_002dweight_002dfunction"><span class="category">User Option: </span><span><strong>company-occurrence-weight-function</strong><a href='#index-company_002doccurrence_002dweight_002dfunction' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002doccurrence_002dweight_002dfunction"><span class="category-def">User Option: </span><span><strong class="def-name">company-occurrence-weight-function</strong><a class="copiable-link" href='#index-company_002doccurrence_002dweight_002dfunction'> &para;</a></span></dt>
 <dd><p>Can be set to one of
-<code><span class="nolinebreak">company-occurrence-prefer-closest-above</span></code><!-- /@w --> (default) or
-<code><span class="nolinebreak">company-occurrence-prefer-any-closest</span></code><!-- /@w -->.  This user option
-defines the behavior of the <code>company-sort-by-occurrence</code>
+<code class="code"><span class="w-nolinebreak-text">company-occurrence-prefer-closest-above</span></code><!-- /@w --> (default) or
+<code class="code"><span class="w-nolinebreak-text">company-occurrence-prefer-any-closest</span></code><!-- /@w -->.  This user option
+defines the behavior of the <code class="code">company-sort-by-occurrence</code>
 transformer function.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dsort_002dby_002dbackend_002dimportance"><span class="category">Function: </span><span><strong>company-sort-by-backend-importance</strong><a href='#index-company_002dsort_002dby_002dbackend_002dimportance' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dsort_002dby_002dbackend_002dimportance"><span class="category-def">Function: </span><span><strong class="def-name">company-sort-by-backend-importance</strong><a class="copiable-link" href='#index-company_002dsort_002dby_002dbackend_002dimportance'> &para;</a></span></dt>
 <dd><p>Sorts candidates as two priority groups, differentiated by the keyword
-<code>:with</code> (see <a href="#Grouped-Backends">Grouped Backends</a>).  Backends positioned in the
-backends list before the keyword <code>:with</code> are treated as more
+<code class="code">:with</code> (see <a class="pxref" href="#Grouped-Backends">Grouped Backends</a>).  Backends positioned in the
+backends list before the keyword <code class="code">:with</code> are treated as more
 important.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dsort_002dprefer_002dsame_002dcase_002dprefix"><span class="category">Function: </span><span><strong>company-sort-prefer-same-case-prefix</strong><a href='#index-company_002dsort_002dprefer_002dsame_002dcase_002dprefix' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dsort_002dprefer_002dsame_002dcase_002dprefix"><span class="category-def">Function: </span><span><strong class="def-name">company-sort-prefer-same-case-prefix</strong><a class="copiable-link" href='#index-company_002dsort_002dprefer_002dsame_002dcase_002dprefix'> &para;</a></span></dt>
 <dd><p>Gives preference to the candidates that match the prefix
 case-insensitively.
 </p></dd></dl>
 
 </div>
 </div>
-<div class="footnote">
+<div class="footnotes-segment">
 <hr>
 <h4 class="footnotes-heading">Footnotes</h4>
 
-<h5><a id="FOOT5" href="#DOCF5">(5)</a></h5>
+<h5 class="footnote-body-heading"><a id="FOOT5" href="#DOCF5">(5)</a></h5>
 <p>The grouped
-backends act as one complex backend.  See <a href="#Grouped-Backends">Grouped Backends</a>.</p>
+backends act as one complex backend.  See <a class="xref" href="#Grouped-Backends">Grouped Backends</a>.</p>
 </div>
 <hr>
-<div class="header">
+<div class="nav-panel">
 <p>
 Next: <a href="Troubleshooting.html" accesskey="n" rel="next">Troubleshooting</a>, Previous: <a href="Frontends.html#Frontends" accesskey="p" rel="prev">Frontends</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>

--- a/manual/Customization.html
+++ b/manual/Customization.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
-<!-- Created by GNU Texinfo 6.8, https://www.gnu.org/software/texinfo/ -->
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <!-- This user manual is for Company version 0.9.14snapshot
-(12 August 2022).
+(16 April 2023).
 
-Copyright (C) 2021-2022  Free Software Foundation, Inc.
+Copyright © 2021-2023  Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -27,21 +27,13 @@ any later version published by the Free Software Foundation. -->
 <link href="Getting-Started.html#Getting-Started" rel="prev" title="Getting Started">
 <style type="text/css">
 <!--
-a.copiable-anchor {visibility: hidden; text-decoration: none; line-height: 0em}
-a.summary-letter {text-decoration: none}
-blockquote.indentedblock {margin-right: 0em}
-div.display {margin-left: 3.2em}
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
 div.example {margin-left: 3.2em}
-kbd {font-style: oblique}
-pre.display {font-family: inherit}
-pre.format {font-family: inherit}
-pre.menu-comment {font-family: serif}
-pre.menu-preformatted {font-family: serif}
-span.nolinebreak {white-space: nowrap}
-span.roman {font-family: initial; font-weight: normal}
-span.sansserif {font-family: sans-serif; font-weight: normal}
-span:hover a.copiable-anchor {visibility: visible}
-ul.no-bullet {list-style: none}
+kbd.kbd {font-style: oblique}
+kbd.key {font-style: normal}
+span.w-nolinebreak-text {white-space: nowrap}
+span:hover a.copiable-link {visibility: visible}
+strong.def-name {font-family: monospace; font-weight: bold; font-size: larger}
 -->
 </style>
 <link rel="stylesheet" type="text/css" href="https://company-mode.github.io/stylesheets/stylesheet.css">
@@ -50,30 +42,30 @@ ul.no-bullet {list-style: none}
 </head>
 
 <body lang="en">
-<div class="inner manual"><div class="chapter" id="Customization">
-<div class="header">
+<div class="inner manual"><div class="chapter-level-extent" id="Customization">
+<div class="nav-panel">
 <p>
 Next: <a href="Frontends.html#Frontends" accesskey="n" rel="next">Frontends</a>, Previous: <a href="Getting-Started.html#Getting-Started" accesskey="p" rel="prev">Getting Started</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>
 <hr>
-<span id="Customization-1"></span><h2 class="chapter">Customization</h2>
+<h2 class="chapter" id="Customization-1">Customization</h2>
 
-<span id="index-configure"></span>
-<span id="index-custom"></span>
+<a class="index-entry-id" id="index-configure"></a>
+<a class="index-entry-id" id="index-custom"></a>
 <p>Emacs provides two equally acceptable ways for user preferences
 configuration: via customization interface (for more details,
 see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Easy-Customization.html#Easy-Customization">(emacs)Easy Customization</a>) and a configuration file
-(see&nbsp;<a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html#Init-File">(emacs)Init&nbsp;File</a>)<!-- /@w -->.  Naturally, Company can be configured
-by both of these approaches.
+(see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html#Init-File">(emacs)Init File</a>).  Naturally, Company can be configured by
+both of these approaches.
 </p>
 
 <hr>
-<div class="section" id="Customization-Interface">
-<span id="Customization-Interface-1"></span><h3 class="section">Customization Interface</h3>
+<div class="section-level-extent" id="Customization-Interface">
+<h3 class="section" id="Customization-Interface-1">Customization Interface</h3>
 
-<span id="index-configure-1"></span>
-<span id="index-custom-1"></span>
-<p>In order to employ the customization interface, run <kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">customize-group</span>&nbsp;<span class="key">RET</span>&nbsp;company</kbd><!-- /@w -->.
+<a class="index-entry-id" id="index-configure-1"></a>
+<a class="index-entry-id" id="index-custom-1"></a>
+<p>In order to employ the customization interface, run <kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">customize-group</span>&nbsp;<kbd class="key">RET</kbd>&nbsp;company</kbd><!-- /@w -->.
 </p>
 <p>This interface outputs all the options available for user
 customization, so you may find it beneficial to review this list even
@@ -84,61 +76,61 @@ Variable</a>.
 </p>
 <hr>
 </div>
-<div class="section" id="Configuration-File">
-<span id="Configuration-File-1"></span><h3 class="section">Configuration File</h3>
+<div class="section-level-extent" id="Configuration-File">
+<h3 class="section" id="Configuration-File-1">Configuration File</h3>
 
-<span id="index-configure-2"></span>
-<span id="index-custom-2"></span>
+<a class="index-entry-id" id="index-configure-2"></a>
+<a class="index-entry-id" id="index-custom-2"></a>
 <p>Company is a customization-rich package.  This section lists some of
 the core settings that influence the overall behavior of the
-<em>company-mode</em>.
+<em class="emph">company-mode</em>.
 </p>
-<dl class="def">
-<dt id="index-company_002dminimum_002dprefix_002dlength"><span class="category">User Option: </span><span><strong>company-minimum-prefix-length</strong><a href='#index-company_002dminimum_002dprefix_002dlength' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>This is one of the values (together with <code>company-idle-delay</code>),
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dminimum_002dprefix_002dlength"><span class="category-def">User Option: </span><span><strong class="def-name">company-minimum-prefix-length</strong><a class="copiable-link" href='#index-company_002dminimum_002dprefix_002dlength'> &para;</a></span></dt>
+<dd><p>This is one of the values (together with <code class="code">company-idle-delay</code>),
 based on which Company auto-stars looking up completion candidates.
 This option configures how many characters have to be typed in by a
 user before candidates start to be collected and displayed.  An often
 choice nowadays is to configure this option to a lower number than the
-default value of <code>3</code>.
+default value of <code class="code">3</code>.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002didle_002ddelay"><span class="category">User Option: </span><span><strong>company-idle-delay</strong><a href='#index-company_002didle_002ddelay' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002didle_002ddelay"><span class="category-def">User Option: </span><span><strong class="def-name">company-idle-delay</strong><a class="copiable-link" href='#index-company_002didle_002ddelay'> &para;</a></span></dt>
 <dd><p>This is the second of the options that configure Company&rsquo;s auto-start
-behavior (together with <code>company-minimum-prefix-length</code>).  The
+behavior (together with <code class="code">company-minimum-prefix-length</code>).  The
 value of this option defines how fast Company is going to react to the
-typed input, such that setting <code>company-idle-delay</code> to <code>0</code>
-makes Company react immediately, <code>nil</code> disables auto-starting,
+typed input, such that setting <code class="code">company-idle-delay</code> to <code class="code">0</code>
+makes Company react immediately, <code class="code">nil</code> disables auto-starting,
 and a larger value postpones completion auto-start for that number of
 seconds.  For an even fancier setup, set this option value to a
 predicate function, as shown in the following example:
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-idle-delay
+<pre class="lisp-preformatted">(setq company-idle-delay
       (lambda () (if (company-in-string-or-comment) nil 0.3)))
 </pre></div>
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dglobal_002dmodes"><span class="category">User Option: </span><span><strong>company-global-modes</strong><a href='#index-company_002dglobal_002dmodes' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>This option allows to specify in which major modes <em>company-mode</em>
-can be enabled by <code>(global-company-mode)</code>. See <a href="Getting-Started.html#Initial-Setup">Initial Setup</a>.
-The default value of <code>t</code> enables Company in all major modes.
-Setting <code>company-global-modes</code> to <code>nil</code> equal in action to
-toggling off <em>global-company-mode</em>.  Providing a list of major
-modes results in having <em>company-mode</em> enabled in the listed
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dglobal_002dmodes"><span class="category-def">User Option: </span><span><strong class="def-name">company-global-modes</strong><a class="copiable-link" href='#index-company_002dglobal_002dmodes'> &para;</a></span></dt>
+<dd><p>This option allows to specify in which major modes <em class="emph">company-mode</em>
+can be enabled by <code class="code">(global-company-mode)</code>. See <a class="xref" href="Getting-Started.html#Initial-Setup">Initial Setup</a>.
+The default value of <code class="code">t</code> enables Company in all major modes.
+Setting <code class="code">company-global-modes</code> to <code class="code">nil</code> equal in action to
+toggling off <em class="emph">global-company-mode</em>.  Providing a list of major
+modes results in having <em class="emph">company-mode</em> enabled in the listed
 modes only.  For the opposite result, provide a list of major modes
-with <code>not</code> being the first element of the list, as shown in the
+with <code class="code">not</code> being the first element of the list, as shown in the
 following example:
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-global-modes '(not erc-mode message-mode eshell-mode))
+<pre class="lisp-preformatted">(setq company-global-modes '(not erc-mode message-mode eshell-mode))
 </pre></div>
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dselection_002dwrap_002daround"><span class="category">User Option: </span><span><strong>company-selection-wrap-around</strong><a href='#index-company_002dselection_002dwrap_002daround' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dselection_002dwrap_002daround"><span class="category-def">User Option: </span><span><strong class="def-name">company-selection-wrap-around</strong><a class="copiable-link" href='#index-company_002dselection_002dwrap_002daround'> &para;</a></span></dt>
 <dd><p>Enable this option to loop (cycle) the candidates&rsquo; selection: after
 selecting the last candidate on the list, a command to select the next
 candidate does so with the first candidate.  By default, this option
@@ -147,74 +139,74 @@ the last item.  The selection of the previous candidate is influenced
 by this option similarly.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002drequire_002dmatch"><span class="category">User Option: </span><span><strong>company-require-match</strong><a href='#index-company_002drequire_002dmatch' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002drequire_002dmatch"><span class="category-def">User Option: </span><span><strong class="def-name">company-require-match</strong><a class="copiable-link" href='#index-company_002drequire_002dmatch'> &para;</a></span></dt>
 <dd><p>To allow typing in characters that don&rsquo;t match the candidates, set the
-value of this option to <code>nil</code>.  For an opposite behavior (that
-is, to disallow non-matching input), set it to <code>t</code>.  By default,
+value of this option to <code class="code">nil</code>.  For an opposite behavior (that
+is, to disallow non-matching input), set it to <code class="code">t</code>.  By default,
 Company is configured to require a matching input only if a user
 manually enables completion or selects a candidate; by having the
 option configured to call the function
-<code>company-explicit-action-p</code>.
+<code class="code">company-explicit-action-p</code>.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dlighter_002dbase"><span class="category">User Option: </span><span><strong>company-lighter-base</strong><a href='#index-company_002dlighter_002dbase' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dlighter_002dbase"><span class="category-def">User Option: </span><span><strong class="def-name">company-lighter-base</strong><a class="copiable-link" href='#index-company_002dlighter_002dbase'> &para;</a></span></dt>
 <dd><p>This user options allows to configure a string indicator of the
-enabled <em>company-mode</em> in the mode line.  The default value is
-&lsquo;<samp>company</samp>&rsquo;.
+enabled <em class="emph">company-mode</em> in the mode line.  The default value is
+&lsquo;<samp class="samp">company</samp>&rsquo;.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dinsertion_002don_002dtrigger"><span class="category">User Option: </span><span><strong>company-insertion-on-trigger</strong><a href='#index-company_002dinsertion_002don_002dtrigger' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dinsertion_002don_002dtrigger"><span class="category-def">User Option: </span><span><strong class="def-name">company-insertion-on-trigger</strong><a class="copiable-link" href='#index-company_002dinsertion_002don_002dtrigger'> &para;</a></span></dt>
 <dd><p>One more pair of the user options may instruct Company to complete
 with the selected candidate by typing one of the
-<code>company-insertion-triggers</code>.  The user option
-<code>company-insertion-on-trigger</code> can be enabled or disabled by
-setting its value to one of: <code>nil</code>, <code>t</code>, or a predicate
+<code class="code">company-insertion-triggers</code>.  The user option
+<code class="code">company-insertion-on-trigger</code> can be enabled or disabled by
+setting its value to one of: <code class="code">nil</code>, <code class="code">t</code>, or a predicate
 function name.
-See <a href="https://www.gnu.org/software/emacs/manual/html_node/eintr/Wrong-Type-of-Argument.html">(eintr)Predicate</a>.
+See <a class="uref" href="https://www.gnu.org/software/emacs/manual/html_node/eintr/Wrong-Type-of-Argument.html">(eintr)Predicate</a>.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dinsertion_002dtriggers"><span class="category">User Option: </span><span><strong>company-insertion-triggers</strong><a href='#index-company_002dinsertion_002dtriggers' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dinsertion_002dtriggers"><span class="category-def">User Option: </span><span><strong class="def-name">company-insertion-triggers</strong><a class="copiable-link" href='#index-company_002dinsertion_002dtriggers'> &para;</a></span></dt>
 <dd><p>This option has an effect only when
-<code><span class="nolinebreak">company-insertion-on-trigger</span></code><!-- /@w --> is enabled.  The value can be
+<code class="code"><span class="w-nolinebreak-text">company-insertion-on-trigger</span></code><!-- /@w --> is enabled.  The value can be
 one of: a string of characters, a list of syntax description
 characters (see <a data-manual="elisp" href="https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-Class-Table.html#Syntax-Class-Table">(elisp)Syntax Class Table</a>), or a predicate
 function.  By default, this user option is set to the list of the
-syntax characters: <code>(?\&nbsp;?\)&nbsp;?.)</code><!-- /@w -->, which translates to the
+syntax characters: <code class="code">(?\&nbsp;?\)&nbsp;?.)</code><!-- /@w -->, which translates to the
 whitespaces, close parenthesis, and punctuation.  It is safe to
 configure the value to a character that can potentially be part of a
 valid completion; in this case, Company does not treat such characters
 as triggers.
 </p></dd></dl>
 
-<span id="Hooks"></span><h4 class="subheading">Hooks</h4>
+<h4 class="subheading" id="Hooks">Hooks</h4>
 
 <p>Company exposes the following life-cycle hooks:
 </p>
-<dl class="def">
-<dt id="index-company_002dcompletion_002dstarted_002dhook"><span class="category">User Option: </span><span><strong>company-completion-started-hook</strong><a href='#index-company_002dcompletion_002dstarted_002dhook' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dcompletion_002dstarted_002dhook"><span class="category-def">User Option: </span><span><strong class="def-name">company-completion-started-hook</strong><a class="copiable-link" href='#index-company_002dcompletion_002dstarted_002dhook'> &para;</a></span></dt>
 </dl>
 
-<dl class="def">
-<dt id="index-company_002dcompletion_002dcancelled_002dhook"><span class="category">User Option: </span><span><strong>company-completion-cancelled-hook</strong><a href='#index-company_002dcompletion_002dcancelled_002dhook' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dcompletion_002dcancelled_002dhook"><span class="category-def">User Option: </span><span><strong class="def-name">company-completion-cancelled-hook</strong><a class="copiable-link" href='#index-company_002dcompletion_002dcancelled_002dhook'> &para;</a></span></dt>
 </dl>
 
-<dl class="def">
-<dt id="index-company_002dcompletion_002dfinished_002dhook"><span class="category">User Option: </span><span><strong>company-completion-finished-hook</strong><a href='#index-company_002dcompletion_002dfinished_002dhook' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dcompletion_002dfinished_002dhook"><span class="category-def">User Option: </span><span><strong class="def-name">company-completion-finished-hook</strong><a class="copiable-link" href='#index-company_002dcompletion_002dfinished_002dhook'> &para;</a></span></dt>
 </dl>
 
-<dl class="def">
-<dt id="index-company_002dafter_002dcompletion_002dhook"><span class="category">User Option: </span><span><strong>company-after-completion-hook</strong><a href='#index-company_002dafter_002dcompletion_002dhook' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dafter_002dcompletion_002dhook"><span class="category-def">User Option: </span><span><strong class="def-name">company-after-completion-hook</strong><a class="copiable-link" href='#index-company_002dafter_002dcompletion_002dhook'> &para;</a></span></dt>
 </dl>
 
 
 </div>
 </div>
 <hr>
-<div class="header">
+<div class="nav-panel">
 <p>
 Next: <a href="Frontends.html#Frontends" accesskey="n" rel="next">Frontends</a>, Previous: <a href="Getting-Started.html#Getting-Started" accesskey="p" rel="prev">Getting Started</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>

--- a/manual/Frontends.html
+++ b/manual/Frontends.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
-<!-- Created by GNU Texinfo 6.8, https://www.gnu.org/software/texinfo/ -->
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <!-- This user manual is for Company version 0.9.14snapshot
-(12 August 2022).
+(16 April 2023).
 
-Copyright (C) 2021-2022  Free Software Foundation, Inc.
+Copyright © 2021-2023  Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -27,21 +27,13 @@ any later version published by the Free Software Foundation. -->
 <link href="Customization.html#Customization" rel="prev" title="Customization">
 <style type="text/css">
 <!--
-a.copiable-anchor {visibility: hidden; text-decoration: none; line-height: 0em}
-a.summary-letter {text-decoration: none}
-blockquote.indentedblock {margin-right: 0em}
-div.display {margin-left: 3.2em}
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
 div.example {margin-left: 3.2em}
-kbd {font-style: oblique}
-pre.display {font-family: inherit}
-pre.format {font-family: inherit}
-pre.menu-comment {font-family: serif}
-pre.menu-preformatted {font-family: serif}
-span.nolinebreak {white-space: nowrap}
-span.roman {font-family: initial; font-weight: normal}
-span.sansserif {font-family: sans-serif; font-weight: normal}
-span:hover a.copiable-anchor {visibility: visible}
-ul.no-bullet {list-style: none}
+kbd.kbd {font-style: oblique}
+kbd.key {font-style: normal}
+span.w-nolinebreak-text {white-space: nowrap}
+span:hover a.copiable-link {visibility: visible}
+strong.def-name {font-family: monospace; font-weight: bold; font-size: larger}
 -->
 </style>
 <link rel="stylesheet" type="text/css" href="https://company-mode.github.io/stylesheets/stylesheet.css">
@@ -50,68 +42,68 @@ ul.no-bullet {list-style: none}
 </head>
 
 <body lang="en">
-<div class="inner manual"><div class="chapter" id="Frontends">
-<div class="header">
+<div class="inner manual"><div class="chapter-level-extent" id="Frontends">
+<div class="nav-panel">
 <p>
 Next: <a href="Backends.html#Backends" accesskey="n" rel="next">Backends</a>, Previous: <a href="Customization.html#Customization" accesskey="p" rel="prev">Customization</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>
 <hr>
-<span id="Frontends-1"></span><h2 class="chapter">Frontends</h2>
+<h2 class="chapter" id="Frontends-1">Frontends</h2>
 
-<span id="index-frontends"></span>
-<span id="index-company_002dfrontends"></span>
+<a class="index-entry-id" id="index-frontends"></a>
+<a class="index-entry-id" id="index-company_002dfrontends"></a>
 <p>Company is packaged with several frontends and provides a predefined
 set of enabled frontends.  A list of the enabled frontends can be
-changed by configuring the user option <code>company-frontends</code>.
+changed by configuring the user option <code class="code">company-frontends</code>.
 </p>
 <p>Each frontend is simply a function that receives a command and acts
 accordingly to it: outputs candidates, hides its output, refreshes
 displayed data, and so on.
 </p>
 <p>All of the Company frontends can be categorized by the type of the
-output into the three groups: <em>tooltip-</em>, <em>preview-</em>, and
-<em>echo-</em> frontends.  We overview these groups in the first sections
+output into the three groups: <em class="dfn">tooltip-</em>, <em class="dfn">preview-</em>, and
+<em class="dfn">echo-</em> frontends.  We overview these groups in the first sections
 of this chapter.  The sections that follow are dedicated to the ways
 the displayed candidates can be searched, filtered, and
 quick-accessed.
 </p>
 
 <hr>
-<div class="section" id="Tooltip-Frontends">
-<span id="Tooltip-Frontends-1"></span><h3 class="section">Tooltip Frontends</h3>
+<div class="section-level-extent" id="Tooltip-Frontends">
+<h3 class="section" id="Tooltip-Frontends-1">Tooltip Frontends</h3>
 
-<span id="index-tooltip"></span>
-<span id="index-pop_002dup"></span>
+<a class="index-entry-id" id="index-tooltip"></a>
+<a class="index-entry-id" id="index-pop_002dup"></a>
 <p>This group of frontends displays completion candidates in an overlayed
-tooltip (aka <span class="nolinebreak">pop-up</span><!-- /@w -->).  Company provides three <em>tooltip
+tooltip (aka <span class="w-nolinebreak-text">pop-up</span><!-- /@w -->).  Company provides three <em class="emph">tooltip
 frontends</em>, listed below.
 </p>
-<dl class="def">
-<dt id="index-company_002dpseudo_002dtooltip_002dunless_002djust_002done_002dfrontend"><span class="category">Function: </span><span><strong>company-pseudo-tooltip-unless-just-one-frontend</strong><a href='#index-company_002dpseudo_002dtooltip_002dunless_002djust_002done_002dfrontend' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dpseudo_002dtooltip_002dunless_002djust_002done_002dfrontend"><span class="category-def">Function: </span><span><strong class="def-name">company-pseudo-tooltip-unless-just-one-frontend</strong><a class="copiable-link" href='#index-company_002dpseudo_002dtooltip_002dunless_002djust_002done_002dfrontend'> &para;</a></span></dt>
 <dd><p>This is one of the default frontends.  It starts displaying a tooltip
 only if more than one completion candidate is available, which nicely
 combines &mdash; and it is done so by default &mdash; with
-<code>company-preview-if-just-one-frontend</code>, <a href="#Preview-Frontends">Preview Frontends</a>.
+<code class="code">company-preview-if-just-one-frontend</code>, <a class="ref" href="#Preview-Frontends">Preview Frontends</a>.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dpseudo_002dtooltip_002dfrontend"><span class="category">Function: </span><span><strong>company-pseudo-tooltip-frontend</strong><a href='#index-company_002dpseudo_002dtooltip_002dfrontend' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dpseudo_002dtooltip_002dfrontend"><span class="category-def">Function: </span><span><strong class="def-name">company-pseudo-tooltip-frontend</strong><a class="copiable-link" href='#index-company_002dpseudo_002dtooltip_002dfrontend'> &para;</a></span></dt>
 <dd><p>This frontend outputs a tooltip for any number of completion
 candidates.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dpseudo_002dtooltip_002dunless_002djust_002done_002dfrontend_002dwith_002ddelay"><span class="category">Function: </span><span><strong>company-pseudo-tooltip-unless-just-one-frontend-with-delay</strong><a href='#index-company_002dpseudo_002dtooltip_002dunless_002djust_002done_002dfrontend_002dwith_002ddelay' class='copiable-anchor'> &para;</a></span></dt>
-<dd><span id="index-company_002dtooltip_002didle_002ddelay"></span>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dpseudo_002dtooltip_002dunless_002djust_002done_002dfrontend_002dwith_002ddelay"><span class="category-def">Function: </span><span><strong class="def-name">company-pseudo-tooltip-unless-just-one-frontend-with-delay</strong><a class="copiable-link" href='#index-company_002dpseudo_002dtooltip_002dunless_002djust_002done_002dfrontend_002dwith_002ddelay'> &para;</a></span></dt>
+<dd><a class="index-entry-id" id="index-company_002dtooltip_002didle_002ddelay"></a>
 <p>This is a peculiar frontend, that displays a tooltip only if more than
 one candidate is available, and only after a delay.  The delay can be
-configured with the user option <code><span class="nolinebreak">company-tooltip-idle-delay</span></code><!-- /@w -->.
+configured with the user option <code class="code"><span class="w-nolinebreak-text">company-tooltip-idle-delay</span></code><!-- /@w -->.
 A typical use case for plugging in this frontend would be displaying a
 tooltip only on a manual request (when needed), as shown in the
 following example:
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-idle-delay 0
+<pre class="lisp-preformatted">(setq company-idle-delay 0
       company-tooltip-idle-delay 10
       company-require-match nil
       company-frontends
@@ -130,82 +122,95 @@ following example:
 </pre></div>
 </dd></dl>
 
-<span id="User-Options"></span><h4 class="subheading">User Options</h4>
+<h4 class="subheading" id="User-Options">User Options</h4>
 
 
-<span id="index-custom-3"></span>
-<span id="index-configure-3"></span>
-<span id="index-interface"></span>
-<p>To change the <em>tooltip frontends</em> configuration, adjust the
+<a class="index-entry-id" id="index-custom-3"></a>
+<a class="index-entry-id" id="index-configure-3"></a>
+<a class="index-entry-id" id="index-interface"></a>
+<p>To change the <em class="emph">tooltip frontends</em> configuration, adjust the
 following user options.
 </p>
-<dl class="def">
-<dt id="index-company_002dtooltip_002dalign_002dannotations"><span class="category">User Option: </span><span><strong>company-tooltip-align-annotations</strong><a href='#index-company_002dtooltip_002dalign_002dannotations' class='copiable-anchor'> &para;</a></span></dt>
-<dd><span id="index-annotation"></span>
-<p>An <em>annotation</em> is a string that carries additional information
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002dalign_002dannotations"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-align-annotations</strong><a class="copiable-link" href='#index-company_002dtooltip_002dalign_002dannotations'> &para;</a></span></dt>
+<dd><a class="index-entry-id" id="index-annotation"></a>
+<p>An <em class="dfn">annotation</em> is a string that carries additional information
 about a candidate; such as a data type, function arguments, or
 whatever a backend appoints to be a valuable piece of information
 about a candidate.  By default, the annotations are shown right beside
-the candidates.  Setting the option value to <code>t</code> aligns
+the candidates.  Setting the option value to <code class="code">t</code> aligns
 annotations to the right side of the tooltip.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-tooltip-align-annotations t)
+<pre class="lisp-preformatted">(setq company-tooltip-align-annotations t)
 </pre></div>
 
-<img src="./images/large/tooltip-annotations.png" alt="./images/large/tooltip-annotations">
+<img class="image" src="./images/large/tooltip-annotations.png" alt="./images/large/tooltip-annotations">
 
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtooltip_002dlimit"><span class="category">User Option: </span><span><strong>company-tooltip-limit</strong><a href='#index-company_002dtooltip_002dlimit' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002dannotation_002dpadding"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-annotation-padding</strong><a class="copiable-link" href='#index-company_002dtooltip_002dannotation_002dpadding'> &para;</a></span></dt>
+<dd><p>Adds left padding to the candidates&rsquo; annotations.  It is disabled by
+default.  If <code class="code">company-tooltip-align-annotations</code> is enabled,
+<code class="code">company-tooltip-annotation-padding</code> defines the minimum spacing
+between a candidate and annotation, with the default value of 1.
+</p>
+<div class="example lisp">
+<pre class="lisp-preformatted">(setq company-tooltip-annotation-padding 1)
+</pre></div>
+
+</dd></dl>
+
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002dlimit"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-limit</strong><a class="copiable-link" href='#index-company_002dtooltip_002dlimit'> &para;</a></span></dt>
 <dd><p>Controls the maximum number of the candidates shown simultaneously in
-the tooltip (the default value is <code>10</code>).  When the number of the
+the tooltip (the default value is <code class="code">10</code>).  When the number of the
 available candidates is larger than this option&rsquo;s value, Company
 paginates the results.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-tooltip-limit 4)
+<pre class="lisp-preformatted">(setq company-tooltip-limit 4)
 </pre></div>
 
-<img src="./images/large/tooltip-limit.png" alt="./images/large/tooltip-limit">
+<img class="image" src="./images/large/tooltip-limit.png" alt="./images/large/tooltip-limit">
 
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtooltip_002doffset_002ddisplay"><span class="category">User Option: </span><span><strong>company-tooltip-offset-display</strong><a href='#index-company_002dtooltip_002doffset_002ddisplay' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002doffset_002ddisplay"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-offset-display</strong><a class="copiable-link" href='#index-company_002dtooltip_002doffset_002ddisplay'> &para;</a></span></dt>
 <dd><p>Use this option to choose in which way to output paginated results.
-The default value is &lsquo;<samp>scrollbar</samp>&rsquo;.  Another supported value is
-&lsquo;<samp>lines</samp>&rsquo;; choose it to show the quantity of the candidates not
+The default value is &lsquo;<samp class="samp">scrollbar</samp>&rsquo;.  Another supported value is
+&lsquo;<samp class="samp">lines</samp>&rsquo;; choose it to show the quantity of the candidates not
 displayed by the current tooltip page.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-tooltip-offset-display 'lines)
+<pre class="lisp-preformatted">(setq company-tooltip-offset-display 'lines)
 </pre></div>
 
-<img src="./images/large/tooltip-offset-display.png" alt="./images/large/tooltip-offset-display">
+<img class="image" src="./images/large/tooltip-offset-display.png" alt="./images/large/tooltip-offset-display">
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtooltip_002dminimum"><span class="category">User Option: </span><span><strong>company-tooltip-minimum</strong><a href='#index-company_002dtooltip_002dminimum' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002dminimum"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-minimum</strong><a class="copiable-link" href='#index-company_002dtooltip_002dminimum'> &para;</a></span></dt>
 <dd><p>This user option acts only when a tooltip is shown close to the bottom
 of a window.  It guarantees visibility of this number of completion
 candidates below point.  When the number of lines between point and
-the bottom of a window is less than <code><span class="nolinebreak">company-tooltip-minimum</span></code><!-- /@w -->
+the bottom of a window is less than <code class="code"><span class="w-nolinebreak-text">company-tooltip-minimum</span></code><!-- /@w -->
 value, the tooltip is displayed above point.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-tooltip-minimum 4)
+<pre class="lisp-preformatted">(setq company-tooltip-minimum 4)
 </pre></div>
 
-<img src="./images/large/tooltip-minimum-below.png" alt="./images/large/tooltip-minimum-below">
+<img class="image" src="./images/large/tooltip-minimum-below.png" alt="./images/large/tooltip-minimum-below">
 
 
-<img src="./images/large/tooltip-minimum-above.png" alt="./images/large/tooltip-minimum-above">
+<img class="image" src="./images/large/tooltip-minimum-above.png" alt="./images/large/tooltip-minimum-above">
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtooltip_002dflip_002dwhen_002dabove"><span class="category">User Option: </span><span><strong>company-tooltip-flip-when-above</strong><a href='#index-company_002dtooltip_002dflip_002dwhen_002dabove' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002dflip_002dwhen_002dabove"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-flip-when-above</strong><a class="copiable-link" href='#index-company_002dtooltip_002dflip_002dwhen_002dabove'> &para;</a></span></dt>
 <dd><p>This is one of the fancy features Company has to suggest.  When this
 setting is enabled, no matter if a tooltip is shown above or below
 point, the candidates are always listed starting near point.  (Putting
@@ -213,161 +218,161 @@ it differently, the candidates are mirrored horizontally if a tooltip
 changes its position, instead of being commonly listed top-to-bottom.)
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-tooltip-flip-when-above t)
+<pre class="lisp-preformatted">(setq company-tooltip-flip-when-above t)
 </pre></div>
 
-<img src="./images/large/tooltip-flip.png" alt="./images/large/tooltip-flip">
+<img class="image" src="./images/large/tooltip-flip.png" alt="./images/large/tooltip-flip">
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtooltip_002dminimum_002dwidth"><span class="category">User Option: </span><span><strong>company-tooltip-minimum-width</strong><a href='#index-company_002dtooltip_002dminimum_002dwidth' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002dminimum_002dwidth"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-minimum-width</strong><a class="copiable-link" href='#index-company_002dtooltip_002dminimum_002dwidth'> &para;</a></span></dt>
 <dd><p>Sets the minimum width of a tooltip, excluding the margins and the
 scroll bar.  Changing this value especially makes sense if a user
 navigates between tooltip pages.  Keeping this value at the default
-<code>0</code> allows Company to always adapt the width of the tooltip to
+<code class="code">0</code> allows Company to always adapt the width of the tooltip to
 the longest shown candidate.  Enlarging
-<code>company-tooltip-minimum-width</code> prevents possible significant
+<code class="code">company-tooltip-minimum-width</code> prevents possible significant
 shifts in the width of the tooltip when navigating to the
 next/previous tooltip page.  (For an alternate solution, see
-<code>company-tooltip-width-grow-only</code>.)
+<code class="code">company-tooltip-width-grow-only</code>.)
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtooltip_002dwidth_002dgrow_002donly"><span class="category">User Option: </span><span><strong>company-tooltip-width-grow-only</strong><a href='#index-company_002dtooltip_002dwidth_002dgrow_002donly' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002dwidth_002dgrow_002donly"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-width-grow-only</strong><a class="copiable-link" href='#index-company_002dtooltip_002dwidth_002dgrow_002donly'> &para;</a></span></dt>
 <dd><p>This is another way to restrict auto-adaptation of the tooltip width
-(another is by adjusting <code>company-tooltip-minimum-width</code> value)
+(another is by adjusting <code class="code">company-tooltip-minimum-width</code> value)
 when navigating between the tooltip pages.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtooltip_002dmaximum_002dwidth"><span class="category">User Option: </span><span><strong>company-tooltip-maximum-width</strong><a href='#index-company_002dtooltip_002dmaximum_002dwidth' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002dmaximum_002dwidth"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-maximum-width</strong><a class="copiable-link" href='#index-company_002dtooltip_002dmaximum_002dwidth'> &para;</a></span></dt>
 <dd><p>This user option controls the maximum width of the tooltip inner area.
 By default, its value is pseudo-limitless, potentially permitting the
 output of extremely long candidates.  But if long lines become an
-issue, set this option to a smaller number, such as <code>60</code> or
-<code>70</code>.
+issue, set this option to a smaller number, such as <code class="code">60</code> or
+<code class="code">70</code>.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtooltip_002dmargin"><span class="category">User Option: </span><span><strong>company-tooltip-margin</strong><a href='#index-company_002dtooltip_002dmargin' class='copiable-anchor'> &para;</a></span></dt>
-<dd><span id="index-margin"></span>
-<p>Controls the width of the <em>margin</em> on the sides of the tooltip
-inner area.  If <code>company-format-margin-function</code> is set,
-<code>company-tooltip-margin</code> defines only the right margin.
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtooltip_002dmargin"><span class="category-def">User Option: </span><span><strong class="def-name">company-tooltip-margin</strong><a class="copiable-link" href='#index-company_002dtooltip_002dmargin'> &para;</a></span></dt>
+<dd><a class="index-entry-id" id="index-margin"></a>
+<p>Controls the width of the <em class="dfn">margin</em> on the sides of the tooltip
+inner area.  If <code class="code">company-format-margin-function</code> is set,
+<code class="code">company-tooltip-margin</code> defines only the right margin.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-tooltip-margin 3)
+<pre class="lisp-preformatted">(setq company-tooltip-margin 3)
 </pre></div>
 
-<img src="./images/large/tooltip-margin.png" alt="./images/large/tooltip-margin">
+<img class="image" src="./images/large/tooltip-margin.png" alt="./images/large/tooltip-margin">
 </dd></dl>
 
-<span id="Candidates-Icons"></span><h4 class="subheading">Candidates Icons</h4>
+<h4 class="subheading" id="Candidates-Icons">Candidates Icons</h4>
 
-<span id="index-icon"></span>
-<span id="index-kind"></span>
-<p>An <em>icon</em> is an image or a text that represents a candidate&rsquo;s
-kind; it is displayed in front of a candidate.  The term <em>kind</em>
+<a class="index-entry-id" id="index-icon"></a>
+<a class="index-entry-id" id="index-kind"></a>
+<p>An <em class="dfn">icon</em> is an image or a text that represents a candidate&rsquo;s
+kind; it is displayed in front of a candidate.  The term <em class="dfn">kind</em>
 here stands for a high-level category a candidate fits into. (Such as
-&lsquo;<samp>array</samp>&rsquo;, &lsquo;<samp>function</samp>&rsquo;, &lsquo;<samp>file</samp>&rsquo;, &lsquo;<samp>string</samp>&rsquo;,
-&lsquo;<samp>color</samp>&rsquo;, etc.  For an extended list of the possible <em>kinds</em>,
-see the user option <code>company-text-icons-mapping</code> or the variable
-<code><span class="nolinebreak">company-vscode-icons-mapping</span></code><!-- /@w -->.)
+&lsquo;<samp class="samp">array</samp>&rsquo;, &lsquo;<samp class="samp">function</samp>&rsquo;, &lsquo;<samp class="samp">file</samp>&rsquo;, &lsquo;<samp class="samp">string</samp>&rsquo;,
+&lsquo;<samp class="samp">color</samp>&rsquo;, etc.  For an extended list of the possible <em class="emph">kinds</em>,
+see the user option <code class="code">company-text-icons-mapping</code> or the variable
+<code class="code"><span class="w-nolinebreak-text">company-vscode-icons-mapping</span></code><!-- /@w -->.)
 </p>
-<dl class="def">
-<dt id="index-company_002dformat_002dmargin_002dfunction"><span class="category">User Option: </span><span><strong>company-format-margin-function</strong><a href='#index-company_002dformat_002dmargin_002dfunction' class='copiable-anchor'> &para;</a></span></dt>
-<dd><span id="index-margin-1"></span>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dformat_002dmargin_002dfunction"><span class="category-def">User Option: </span><span><strong class="def-name">company-format-margin-function</strong><a class="copiable-link" href='#index-company_002dformat_002dmargin_002dfunction'> &para;</a></span></dt>
+<dd><a class="index-entry-id" id="index-margin-1"></a>
 <p>Allows setting a function to format the left margin of a tooltip inner
-area; namely, to output candidate&rsquo;s <em>icons</em>.  The predefined
+area; namely, to output candidate&rsquo;s <em class="emph">icons</em>.  The predefined
 formatting functions are listed below.  A user may also set this
 option to a custom function. To disable left margin formatting, set
-the value of the option to <code>nil</code> (this way control over the size
+the value of the option to <code class="code">nil</code> (this way control over the size
 of the left margin returns to the user option
-<code>company-tooltip-margin</code>).
+<code class="code">company-tooltip-margin</code>).
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dvscode_002ddark_002dicons_002dmargin"><span class="category">Function: </span><span><strong>company-vscode-dark-icons-margin</strong><a href='#index-company_002dvscode_002ddark_002dicons_002dmargin' class='copiable-anchor'> &para;</a></span></dt>
-<dt id="index-company_002dvscode_002dlight_002dicons_002dmargin"><span class="category">Function: </span><span><strong>company-vscode-light-icons-margin</strong><a href='#index-company_002dvscode_002dlight_002dicons_002dmargin' class='copiable-anchor'> &para;</a></span></dt>
-<dd><span id="index-company_002dicon_002dsize"></span>
-<span id="index-company_002dicon_002dmargin"></span>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dvscode_002ddark_002dicons_002dmargin"><span class="category-def">Function: </span><span><strong class="def-name">company-vscode-dark-icons-margin</strong><a class="copiable-link" href='#index-company_002dvscode_002ddark_002dicons_002dmargin'> &para;</a></span></dt>
+<dt class="deffnx defunx-alias-deffnx def-cmd-deffn" id="index-company_002dvscode_002dlight_002dicons_002dmargin"><span class="category-def">Function: </span><span><strong class="def-name">company-vscode-light-icons-margin</strong><a class="copiable-link" href='#index-company_002dvscode_002dlight_002dicons_002dmargin'> &para;</a></span></dt>
+<dd><a class="index-entry-id" id="index-company_002dicon_002dsize"></a>
+<a class="index-entry-id" id="index-company_002dicon_002dmargin"></a>
 <p>These functions utilize VSCode dark and light theme icon sets
-<a id="DOCF3" href="#FOOT3"><sup>3</sup></a>.  The related two user
-options are <code>company-icon-size</code> and <code>company-icon-margin</code>.
+<a class="footnote" id="DOCF3" href="#FOOT3"><sup>3</sup></a>.  The related two user
+options are <code class="code">company-icon-size</code> and <code class="code">company-icon-margin</code>.
 </p>
-<img src="./images/large/tooltip-icons-vscode.png" alt="./images/large/tooltip-icons-vscode">
+<img class="image" src="./images/large/tooltip-icons-vscode.png" alt="./images/large/tooltip-icons-vscode">
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtext_002dicons_002dmargin"><span class="category">Function: </span><span><strong>company-text-icons-margin</strong><a href='#index-company_002dtext_002dicons_002dmargin' class='copiable-anchor'> &para;</a></span></dt>
-<dd><span id="index-company_002dtext_002dicons_002dformat"></span>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dtext_002dicons_002dmargin"><span class="category-def">Function: </span><span><strong class="def-name">company-text-icons-margin</strong><a class="copiable-link" href='#index-company_002dtext_002dicons_002dmargin'> &para;</a></span></dt>
+<dd><a class="index-entry-id" id="index-company_002dtext_002dicons_002dformat"></a>
 <p>This function produces letters and symbols formatted according to the
-<code><span class="nolinebreak">company-text-icons-format</span></code><!-- /@w -->.  The rest of the user options
+<code class="code"><span class="w-nolinebreak-text">company-text-icons-format</span></code><!-- /@w -->.  The rest of the user options
 affecting this function behavior are listed below.
 </p>
-<img src="./images/large/tooltip-icons-text.png" alt="./images/large/tooltip-icons-text">
+<img class="image" src="./images/large/tooltip-icons-text.png" alt="./images/large/tooltip-icons-text">
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002ddot_002dicons_002dmargin"><span class="category">Function: </span><span><strong>company-dot-icons-margin</strong><a href='#index-company_002ddot_002dicons_002dmargin' class='copiable-anchor'> &para;</a></span></dt>
-<dd><span id="index-company_002ddot_002dicons_002dformat"></span>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002ddot_002dicons_002dmargin"><span class="category-def">Function: </span><span><strong class="def-name">company-dot-icons-margin</strong><a class="copiable-link" href='#index-company_002ddot_002dicons_002dmargin'> &para;</a></span></dt>
+<dd><a class="index-entry-id" id="index-company_002ddot_002dicons_002dformat"></a>
 <p>This function produces a colored Unicode symbol of a circle formatted
-according to the <code><span class="nolinebreak">company-dot-icons-format</span></code><!-- /@w -->.  Other user
+according to the <code class="code"><span class="w-nolinebreak-text">company-dot-icons-format</span></code><!-- /@w -->.  Other user
 options that affect the resulting output are listed below.
 </p>
-<img src="./images/large/tooltip-icons-dot.png" alt="./images/large/tooltip-icons-dot">
+<img class="image" src="./images/large/tooltip-icons-dot.png" alt="./images/large/tooltip-icons-dot">
 </dd></dl>
 
-<p>The following user options influence appearance of the <em>text</em> and
-<em>dot</em> <em>icons</em>.
+<p>The following user options influence appearance of the <em class="emph">text</em> and
+<em class="emph">dot</em> <em class="emph">icons</em>.
 </p>
-<dl class="def">
-<dt id="index-company_002dtext_002dicons_002dmapping"><span class="category">User Option: </span><span><strong>company-text-icons-mapping</strong><a href='#index-company_002dtext_002dicons_002dmapping' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>Lists candidates&rsquo; <em>kinds</em> with their corresponding <em>icons</em>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtext_002dicons_002dmapping"><span class="category-def">User Option: </span><span><strong class="def-name">company-text-icons-mapping</strong><a class="copiable-link" href='#index-company_002dtext_002dicons_002dmapping'> &para;</a></span></dt>
+<dd><p>Lists candidates&rsquo; <em class="emph">kinds</em> with their corresponding <em class="emph">icons</em>
 configurations.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtext_002dface_002dextra_002dattributes"><span class="category">User Option: </span><span><strong>company-text-face-extra-attributes</strong><a href='#index-company_002dtext_002dface_002dextra_002dattributes' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>A list of face attributes to be applied to the <em>icons</em>.
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtext_002dface_002dextra_002dattributes"><span class="category-def">User Option: </span><span><strong class="def-name">company-text-face-extra-attributes</strong><a class="copiable-link" href='#index-company_002dtext_002dface_002dextra_002dattributes'> &para;</a></span></dt>
+<dd><p>A list of face attributes to be applied to the <em class="emph">icons</em>.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-text-face-extra-attributes
+<pre class="lisp-preformatted">(setq company-text-face-extra-attributes
       '(:weight bold :slant italic))
 </pre></div>
 
-<img src="./images/large/tooltip-icon-face.png" alt="./images/large/tooltip-icon-face">
+<img class="image" src="./images/large/tooltip-icon-face.png" alt="./images/large/tooltip-icon-face">
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dtext_002dicons_002dadd_002dbackground"><span class="category">User Option: </span><span><strong>company-text-icons-add-background</strong><a href='#index-company_002dtext_002dicons_002dadd_002dbackground' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>If this option is enabled, when an <em>icon</em> doesn&rsquo;t have a
-background configured by <code>company-text-icons-mapping</code>, then a
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dtext_002dicons_002dadd_002dbackground"><span class="category-def">User Option: </span><span><strong class="def-name">company-text-icons-add-background</strong><a class="copiable-link" href='#index-company_002dtext_002dicons_002dadd_002dbackground'> &para;</a></span></dt>
+<dd><p>If this option is enabled, when an <em class="emph">icon</em> doesn&rsquo;t have a
+background configured by <code class="code">company-text-icons-mapping</code>, then a
 generated background is applied.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-text-icons-add-background t)
+<pre class="lisp-preformatted">(setq company-text-icons-add-background t)
 </pre></div>
 
-<img src="./images/large/tooltip-icon-bg.png" alt="./images/large/tooltip-icon-bg">
+<img class="image" src="./images/large/tooltip-icon-bg.png" alt="./images/large/tooltip-icon-bg">
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002ddetect_002dicons_002dmargin"><span class="category">Function: </span><span><strong>company-detect-icons-margin</strong><a href='#index-company_002ddetect_002dicons_002dmargin' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002ddetect_002dicons_002dmargin"><span class="category-def">Function: </span><span><strong class="def-name">company-detect-icons-margin</strong><a class="copiable-link" href='#index-company_002ddetect_002dicons_002dmargin'> &para;</a></span></dt>
 <dd><p>This is the default margin formatting function, that applies one of
-the <code><span class="nolinebreak">company-vscode-*-icons-margin</span></code><!-- /@w --> functions if
-&lsquo;<samp>vscode</samp>&rsquo; icons set is supported; otherwise applies a
-<code><span class="nolinebreak">company-text-icons-margin</span></code><!-- /@w --> function.
+the <code class="code"><span class="w-nolinebreak-text">company-vscode-*-icons-margin</span></code><!-- /@w --> functions if
+&lsquo;<samp class="samp">vscode</samp>&rsquo; icons set is supported; otherwise applies a
+<code class="code"><span class="w-nolinebreak-text">company-text-icons-margin</span></code><!-- /@w --> function.
 </p></dd></dl>
 
-<span id="Faces"></span><h4 class="subheading">Faces</h4>
-<span id="index-company_002dtooltip"></span>
-<span id="index-face"></span>
-<span id="index-font"></span>
-<span id="index-color"></span>
-<span id="index-interface-1"></span>
-<span id="index-custom-4"></span>
-<span id="index-configure-4"></span>
+<h4 class="subheading" id="Faces">Faces</h4>
+<a class="index-entry-id" id="index-company_002dtooltip"></a>
+<a class="index-entry-id" id="index-face"></a>
+<a class="index-entry-id" id="index-font"></a>
+<a class="index-entry-id" id="index-color"></a>
+<a class="index-entry-id" id="index-interface-1"></a>
+<a class="index-entry-id" id="index-custom-4"></a>
+<a class="index-entry-id" id="index-configure-4"></a>
 <p>Out-of-the-box Company defines and configures distinguished faces
 (see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Faces.html#Faces">(emacs)Faces</a>) for light and dark themes.  Moreover, some of
 the built-in and third-party themes fine-tune Company to fit their
@@ -376,13 +381,13 @@ adjustments on a user side.  However, this chapter presents some hints
 on where to start customizing Company interface.
 </p>
 <p>Namely, the look of a tooltip is controlled by the
-<code>company-tooltip*</code> named faces.
+<code class="code">company-tooltip*</code> named faces.
 </p>
 <p>The following example hints how a user may approach tooltip faces
 customization:
 </p>
 <div class="example lisp">
-<pre class="lisp">(custom-set-faces
+<pre class="lisp-preformatted">(custom-set-faces
  '(company-tooltip
    ((t (:background &quot;ivory&quot; :foreground &quot;MistyRose3&quot;))))
  '(company-tooltip-selection
@@ -393,243 +398,243 @@ customization:
  '(company-tooltip-annotation ((t (:foreground &quot;MistyRose2&quot;)))))
 </pre></div>
 
-<img src="./images/large/tooltip-faces-light.png" alt="./images/large/tooltip-faces-light">
+<img class="image" src="./images/large/tooltip-faces-light.png" alt="./images/large/tooltip-faces-light">
 
 <hr>
 </div>
-<div class="section" id="Preview-Frontends">
-<span id="Preview-Frontends-1"></span><h3 class="section">Preview Frontends</h3>
+<div class="section-level-extent" id="Preview-Frontends">
+<h3 class="section" id="Preview-Frontends-1">Preview Frontends</h3>
 
-<span id="index-preview"></span>
-<span id="index-face-1"></span>
-<span id="index-company_002dpreview"></span>
-<span id="index-candidate-3"></span>
-<span id="index-common-part-2"></span>
-<span id="index-complete-5"></span>
+<a class="index-entry-id" id="index-preview"></a>
+<a class="index-entry-id" id="index-face-1"></a>
+<a class="index-entry-id" id="index-company_002dpreview"></a>
+<a class="index-entry-id" id="index-candidate-3"></a>
+<a class="index-entry-id" id="index-common-part-2"></a>
+<a class="index-entry-id" id="index-complete-5"></a>
 <p>Frontends in this group output a completion candidate or a common part
 of the candidates temporarily inline, as if a word had already been
-completed <a id="DOCF4" href="#FOOT4"><sup>4</sup></a>.
+completed <a class="footnote" id="DOCF4" href="#FOOT4"><sup>4</sup></a>.
 </p>
-<dl class="def">
-<dt id="index-company_002dpreview_002dif_002djust_002done_002dfrontend"><span class="category">Function: </span><span><strong>company-preview-if-just-one-frontend</strong><a href='#index-company_002dpreview_002dif_002djust_002done_002dfrontend' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dpreview_002dif_002djust_002done_002dfrontend"><span class="category-def">Function: </span><span><strong class="def-name">company-preview-if-just-one-frontend</strong><a class="copiable-link" href='#index-company_002dpreview_002dif_002djust_002done_002dfrontend'> &para;</a></span></dt>
 <dd><p>This is one of the frontends enabled by default.  This frontend
 outputs a preview if only one completion candidate is available; it is
 a good suit to be combined with
-<code><span class="nolinebreak">company-pseudo-tooltip-unless-just-one-frontend</span></code><!-- /@w -->,
-<a href="#Tooltip-Frontends">Tooltip Frontends</a>.
+<code class="code"><span class="w-nolinebreak-text">company-pseudo-tooltip-unless-just-one-frontend</span></code><!-- /@w -->,
+<a class="ref" href="#Tooltip-Frontends">Tooltip Frontends</a>.
 </p></dd></dl>
 
 
-<dl class="def">
-<dt id="index-company_002dpreview_002dfrontend"><span class="category">Function: </span><span><strong>company-preview-frontend</strong><a href='#index-company_002dpreview_002dfrontend' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dpreview_002dfrontend"><span class="category-def">Function: </span><span><strong class="def-name">company-preview-frontend</strong><a class="copiable-link" href='#index-company_002dpreview_002dfrontend'> &para;</a></span></dt>
 <dd><p>This frontend outputs the first of the available completion candidates
 inline for a preview.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dpreview_002dcommon_002dfrontend"><span class="category">Function: </span><span><strong>company-preview-common-frontend</strong><a href='#index-company_002dpreview_002dcommon_002dfrontend' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dpreview_002dcommon_002dfrontend"><span class="category-def">Function: </span><span><strong class="def-name">company-preview-common-frontend</strong><a class="copiable-link" href='#index-company_002dpreview_002dcommon_002dfrontend'> &para;</a></span></dt>
 <dd><p>As the name of this frontend suggests, it outputs for a preview only a
 common part of the candidates.
 </p></dd></dl>
 
-<span id="index-custom-5"></span>
-<span id="index-configure-5"></span>
-<span id="index-interface-2"></span>
-<span id="index-face-2"></span>
+<a class="index-entry-id" id="index-custom-5"></a>
+<a class="index-entry-id" id="index-configure-5"></a>
+<a class="index-entry-id" id="index-interface-2"></a>
+<a class="index-entry-id" id="index-face-2"></a>
 <p>The look of the preview is controlled by the following faces:
-<code>company-preview</code>, <code>company-preview-common</code>, and
-<code>company-preview-search</code>.
+<code class="code">company-preview</code>, <code class="code">company-preview-common</code>, and
+<code class="code">company-preview-search</code>.
 </p>
-<img src="./images/large/preview-light.png" alt="./images/large/preview-light">
+<img class="image" src="./images/large/preview-light.png" alt="./images/large/preview-light">
 
 
-<img src="./images/large/preview-dark.png" alt="./images/large/preview-dark">
+<img class="image" src="./images/large/preview-dark.png" alt="./images/large/preview-dark">
 
 <hr>
 </div>
-<div class="section" id="Echo-Frontends">
-<span id="Echo-Frontends-1"></span><h3 class="section">Echo Frontends</h3>
+<div class="section-level-extent" id="Echo-Frontends">
+<h3 class="section" id="Echo-Frontends-1">Echo Frontends</h3>
 
-<span id="index-echo"></span>
-<span id="index-face-3"></span>
-<span id="index-company_002decho"></span>
+<a class="index-entry-id" id="index-echo"></a>
+<a class="index-entry-id" id="index-face-3"></a>
+<a class="index-entry-id" id="index-company_002decho"></a>
 <p>The frontends listed in this section display information in the
 Emacs&rsquo;s echo area, <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Echo-Area.html#Echo-Area">(emacs)Echo Area</a>.
 </p>
-<dl class="def">
-<dt id="index-company_002decho_002dmetadata_002dfrontend"><span class="category">Function: </span><span><strong>company-echo-metadata-frontend</strong><a href='#index-company_002decho_002dmetadata_002dfrontend' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002decho_002dmetadata_002dfrontend"><span class="category-def">Function: </span><span><strong class="def-name">company-echo-metadata-frontend</strong><a class="copiable-link" href='#index-company_002decho_002dmetadata_002dfrontend'> &para;</a></span></dt>
 <dd><p>This frontend is a part of the predefined frontends set.  Its
 responsibility is to output a short documentation string for a
 completion candidate in the echo area.
 </p>
-<img src="./images/large/echo-meta.png" alt="./images/large/echo-meta">
+<img class="image" src="./images/large/echo-meta.png" alt="./images/large/echo-meta">
 </dd></dl>
 
 <br>
 <p>The last pair of the built-in frontends isn&rsquo;t that commonly used and
-not as full-featured as the previously reviewed <em>tooltip-</em> and
-<em>preview-</em> frontends, but still, feel free to play with them and
+not as full-featured as the previously reviewed <em class="emph">tooltip-</em> and
+<em class="emph">preview-</em> frontends, but still, feel free to play with them and
 have some fun!
 </p>
-<dl class="def">
-<dt id="index-company_002decho_002dfrontend"><span class="category">Function: </span><span><strong>company-echo-frontend</strong><a href='#index-company_002decho_002dfrontend' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002decho_002dfrontend"><span class="category-def">Function: </span><span><strong class="def-name">company-echo-frontend</strong><a class="copiable-link" href='#index-company_002decho_002dfrontend'> &para;</a></span></dt>
 <dd><p>This frontend outputs all the available completion candidates in the
 echo area.
 </p>
-<img src="./images/large/echo.png" alt="./images/large/echo">
+<img class="image" src="./images/large/echo.png" alt="./images/large/echo">
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002decho_002dstrip_002dcommon_002dfrontend"><span class="category">Function: </span><span><strong>company-echo-strip-common-frontend</strong><a href='#index-company_002decho_002dstrip_002dcommon_002dfrontend' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002decho_002dstrip_002dcommon_002dfrontend"><span class="category-def">Function: </span><span><strong class="def-name">company-echo-strip-common-frontend</strong><a class="copiable-link" href='#index-company_002decho_002dstrip_002dcommon_002dfrontend'> &para;</a></span></dt>
 <dd><p>It acts similarly to the previous frontend but outputs a common part
 of the candidates once for all of them.
 </p>
-<img src="./images/large/echo-strip.png" alt="./images/large/echo-strip">
+<img class="image" src="./images/large/echo-strip.png" alt="./images/large/echo-strip">
 </dd></dl>
 
-<dl class="def">
-<dt id="index-company_002decho_002dtruncate_002dlines"><span class="category">User Option: </span><span><strong>company-echo-truncate-lines</strong><a href='#index-company_002decho_002dtruncate_002dlines' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>This is the only <em>echo frontends</em> targeted setting.  When
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002decho_002dtruncate_002dlines"><span class="category-def">User Option: </span><span><strong class="def-name">company-echo-truncate-lines</strong><a class="copiable-link" href='#index-company_002decho_002dtruncate_002dlines'> &para;</a></span></dt>
+<dd><p>This is the only <em class="emph">echo frontends</em> targeted setting.  When
 enabled, the output is truncated to fit the echo area.  This setting
-is set to <code>t</code> by default.
+is set to <code class="code">t</code> by default.
 </p></dd></dl>
 
-<span id="index-custom-6"></span>
-<span id="index-configure-6"></span>
-<span id="index-interface-3"></span>
-<span id="index-face-4"></span>
+<a class="index-entry-id" id="index-custom-6"></a>
+<a class="index-entry-id" id="index-configure-6"></a>
+<a class="index-entry-id" id="index-interface-3"></a>
+<a class="index-entry-id" id="index-face-4"></a>
 <p>To apply visual changes to the output of these frontends, configure
-the faces <code><span class="nolinebreak">company-echo</span></code><!-- /@w --> and <code>company-echo-common</code>.
+the faces <code class="code"><span class="w-nolinebreak-text">company-echo</span></code><!-- /@w --> and <code class="code">company-echo-common</code>.
 </p>
 <hr>
 </div>
-<div class="section" id="Candidates-Search">
-<span id="Candidates-Search-1"></span><h3 class="section">Candidates Search</h3>
+<div class="section-level-extent" id="Candidates-Search">
+<h3 class="section" id="Candidates-Search-1">Candidates Search</h3>
 
-<span id="index-search"></span>
-<span id="index-face-5"></span>
-<span id="index-company_002dtooltip_002dsearch"></span>
-<span id="index-C_002ds"></span>
-<p>By default, when <em>company-mode</em> is in action, a key binding
-<kbd>C-s</kbd> starts looking for matches to additionally typed characters
+<a class="index-entry-id" id="index-search"></a>
+<a class="index-entry-id" id="index-face-5"></a>
+<a class="index-entry-id" id="index-company_002dtooltip_002dsearch"></a>
+<a class="index-entry-id" id="index-C_002ds"></a>
+<p>By default, when <em class="emph">company-mode</em> is in action, a key binding
+<kbd class="kbd">C-s</kbd> starts looking for matches to additionally typed characters
 among the displayed candidates.  When a search is initiated, an
-indicator &lsquo;<samp>Search:&nbsp;CHARACTERS</samp>&rsquo;<!-- /@w --> is shown in the Emacs&rsquo;s mode
+indicator &lsquo;<samp class="samp">Search:&nbsp;CHARACTERS</samp>&rsquo;<!-- /@w --> is shown in the Emacs&rsquo;s mode
 line.
 </p>
-<span id="index-C_002dg-2"></span>
-<p>To quit the search mode, hit <kbd>C-g</kbd>.
+<a class="index-entry-id" id="index-C_002dg-2"></a>
+<p>To quit the search mode, hit <kbd class="kbd">C-g</kbd>.
 </p>
-<dl class="def">
-<dt id="index-company_002dsearch_002dregexp_002dfunction"><span class="category">User Option: </span><span><strong>company-search-regexp-function</strong><a href='#index-company_002dsearch_002dregexp_002dfunction' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-defvr first-defopt-alias-first-defvr">
+<dt class="defvr defopt-alias-defvr" id="index-company_002dsearch_002dregexp_002dfunction"><span class="category-def">User Option: </span><span><strong class="def-name">company-search-regexp-function</strong><a class="copiable-link" href='#index-company_002dsearch_002dregexp_002dfunction'> &para;</a></span></dt>
 <dd><p>The value of this user option must be a function that interprets the
 search input.  By default it is set to the function
-<code>regexp-quote</code>, with looks for an exact match.  Company defines
+<code class="code">regexp-quote</code>, with looks for an exact match.  Company defines
 several more functions suitable for this option. They are listed below.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dsearch_002dwords_002dregexp"><span class="category">Function: </span><span><strong>company-search-words-regexp</strong><a href='#index-company_002dsearch_002dwords_002dregexp' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dsearch_002dwords_002dregexp"><span class="category-def">Function: </span><span><strong class="def-name">company-search-words-regexp</strong><a class="copiable-link" href='#index-company_002dsearch_002dwords_002dregexp'> &para;</a></span></dt>
 <dd><p>Searches for words separated with spaces in the given order.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dsearch_002dwords_002din_002dany_002dorder_002dregexp"><span class="category">Function: </span><span><strong>company-search-words-in-any-order-regexp</strong><a href='#index-company_002dsearch_002dwords_002din_002dany_002dorder_002dregexp' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dsearch_002dwords_002din_002dany_002dorder_002dregexp"><span class="category-def">Function: </span><span><strong class="def-name">company-search-words-in-any-order-regexp</strong><a class="copiable-link" href='#index-company_002dsearch_002dwords_002din_002dany_002dorder_002dregexp'> &para;</a></span></dt>
 <dd><p>Searches for words separated with spaces in any order.
 </p></dd></dl>
 
-<dl class="def">
-<dt id="index-company_002dsearch_002dflex_002dregexp"><span class="category">Function: </span><span><strong>company-search-flex-regexp</strong><a href='#index-company_002dsearch_002dflex_002dregexp' class='copiable-anchor'> &para;</a></span></dt>
+<dl class="first-deffn first-defun-alias-first-deffn">
+<dt class="deffn defun-alias-deffn" id="index-company_002dsearch_002dflex_002dregexp"><span class="category-def">Function: </span><span><strong class="def-name">company-search-flex-regexp</strong><a class="copiable-link" href='#index-company_002dsearch_002dflex_002dregexp'> &para;</a></span></dt>
 <dd><p>Searches for characters in the given order, with anything in between.
 </p></dd></dl>
 
-<span id="index-custom-7"></span>
-<span id="index-configure-7"></span>
-<span id="index-interface-4"></span>
-<span id="index-face-6"></span>
-<p>Search matches are distinguished by the <code>company-tooltip-search</code>
-and <code><span class="nolinebreak">company-tooltip-search-selection</span></code><!-- /@w --> faces.
+<a class="index-entry-id" id="index-custom-7"></a>
+<a class="index-entry-id" id="index-configure-7"></a>
+<a class="index-entry-id" id="index-interface-4"></a>
+<a class="index-entry-id" id="index-face-6"></a>
+<p>Search matches are distinguished by the <code class="code">company-tooltip-search</code>
+and <code class="code"><span class="w-nolinebreak-text">company-tooltip-search-selection</span></code><!-- /@w --> faces.
 </p>
-<img src="./images/large/tooltip-search.png" alt="./images/large/tooltip-search">
+<img class="image" src="./images/large/tooltip-search.png" alt="./images/large/tooltip-search">
 
 <hr>
 </div>
-<div class="section" id="Filter-Candidates">
-<span id="Filter-Candidates-1"></span><h3 class="section">Filter Candidates</h3>
+<div class="section-level-extent" id="Filter-Candidates">
+<h3 class="section" id="Filter-Candidates-1">Filter Candidates</h3>
 
-<span id="index-filter"></span>
-<span id="index-face-7"></span>
-<span id="index-C_002dM_002ds"></span>
+<a class="index-entry-id" id="index-filter"></a>
+<a class="index-entry-id" id="index-face-7"></a>
+<a class="index-entry-id" id="index-C_002dM_002ds"></a>
 <p>Candidates filtering is started by typing the default key binding
-<kbd>C-M-s</kbd>.  Filtering acts on a par with the search
-(see <a href="#Candidates-Search">Candidates Search</a>), indicating its activation by the text
-&lsquo;<samp>Filter:&nbsp;CHARACTERS</samp>&rsquo;<!-- /@w --> in the mode line and influencing the
+<kbd class="kbd">C-M-s</kbd>.  Filtering acts on a par with the search
+(see <a class="pxref" href="#Candidates-Search">Candidates Search</a>), indicating its activation by the text
+&lsquo;<samp class="samp">Filter:&nbsp;CHARACTERS</samp>&rsquo;<!-- /@w --> in the mode line and influencing the
 displayed candidates.  The difference is that the filtering, as its
 name suggests, keeps displaying only the matching candidates (in
 addition to distinguishing the matches with a face).
 </p>
-<span id="index-C_002dg-3"></span>
-<span id="index-C_002do"></span>
-<p>To quit the filtering, hit <kbd>C-g</kbd>.  To toggle between search and
-filter states, use key binding <kbd>C-o</kbd>.
+<a class="index-entry-id" id="index-C_002dg-3"></a>
+<a class="index-entry-id" id="index-C_002do"></a>
+<p>To quit the filtering, hit <kbd class="kbd">C-g</kbd>.  To toggle between search and
+filter states, use key binding <kbd class="kbd">C-o</kbd>.
 </p>
-<img src="./images/large/tooltip-filter.png" alt="./images/large/tooltip-filter">
+<img class="image" src="./images/large/tooltip-filter.png" alt="./images/large/tooltip-filter">
 
 <hr>
 </div>
-<div class="section" id="Quick-Access-a-Candidate">
-<span id="Quick-Access-a-Candidate-1"></span><h3 class="section">Quick Access a Candidate</h3>
+<div class="section-level-extent" id="Quick-Access-a-Candidate">
+<h3 class="section" id="Quick-Access-a-Candidate-1">Quick Access a Candidate</h3>
 
-<span id="index-quick_002daccess"></span>
-<span id="index-M_002d_003cdigit_003e"></span>
+<a class="index-entry-id" id="index-quick_002daccess"></a>
+<a class="index-entry-id" id="index-M_002d_003cdigit_003e"></a>
 <p>Company provides a way to choose a candidate for completion without
 having to navigate to that candidate: by hitting one of the
-<span class="nolinebreak">quick-access</span><!-- /@w --> keys.  By default, <span class="nolinebreak">quick-access</span><!-- /@w --> key bindings
-utilize a modifier <tt class="key">META</tt> and one of the digits, such that
-pressing <kbd>M-1</kbd> completes with the first candidate on the list and
-<kbd>M-0</kbd> with the tenth candidate.
+<span class="w-nolinebreak-text">quick-access</span><!-- /@w --> keys.  By default, <span class="w-nolinebreak-text">quick-access</span><!-- /@w --> key bindings
+utilize a modifier <kbd class="key">META</kbd> and one of the digits, such that
+pressing <kbd class="kbd">M-1</kbd> completes with the first candidate on the list and
+<kbd class="kbd">M-0</kbd> with the tenth candidate.
 </p>
-<span id="index-company_002dshow_002dquick_002daccess"></span>
-<p>If <code>company-show-quick-access</code> is enabled, <em>tooltip-</em> and
-<em>echo-</em> frontends show <span class="nolinebreak">quick-access</span><!-- /@w --> hints.
+<a class="index-entry-id" id="index-company_002dshow_002dquick_002daccess"></a>
+<p>If <code class="code">company-show-quick-access</code> is enabled, <em class="emph">tooltip-</em> and
+<em class="emph">echo-</em> frontends show <span class="w-nolinebreak-text">quick-access</span><!-- /@w --> hints.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-show-quick-access 'left)
+<pre class="lisp-preformatted">(setq company-show-quick-access 'left)
 </pre></div>
 
-<img src="./images/large/tooltip-quick-access.png" alt="./images/large/tooltip-quick-access">
+<img class="image" src="./images/large/tooltip-quick-access.png" alt="./images/large/tooltip-quick-access">
 
 
-<img src="./images/large/echo-qa.png" alt="./images/large/echo-qa">
+<img class="image" src="./images/large/echo-qa.png" alt="./images/large/echo-qa">
 
 
-<img src="./images/large/echo-strip-qa.png" alt="./images/large/echo-strip-qa">
+<img class="image" src="./images/large/echo-strip-qa.png" alt="./images/large/echo-strip-qa">
 
-<span id="index-custom-8"></span>
-<span id="index-configure-8"></span>
+<a class="index-entry-id" id="index-custom-8"></a>
+<a class="index-entry-id" id="index-configure-8"></a>
 <p>To customize the key bindings, either do it via Customization
-Interface (see <a href="Customization.html#Customization-Interface">Customization Interface</a>) or use the following
+Interface (see <a class="pxref" href="Customization.html#Customization-Interface">Customization Interface</a>) or use the following
 approach:
 </p>
 <div class="example lisp">
-<pre class="lisp">(custom-set-variables
+<pre class="lisp-preformatted">(custom-set-variables
  '(company-quick-access-keys '(&quot;a&quot; &quot;o&quot; &quot;e&quot; &quot;u&quot; &quot;i&quot;))
  '(company-quick-access-modifier 'super))
 </pre></div>
 
-<p>A modifier should be one of <code>meta</code>, <code>super</code>, <code>hyper</code>,
-<code> control</code>.
+<p>A modifier should be one of <code class="code">meta</code>, <code class="code">super</code>, <code class="code">hyper</code>,
+<code class="code"> control</code>.
 </p>
-<span id="index-face-8"></span>
-<span id="index-font-1"></span>
-<span id="index-color-1"></span>
-<span id="index-interface-5"></span>
-<span id="index-custom-9"></span>
-<span id="index-configure-9"></span>
+<a class="index-entry-id" id="index-face-8"></a>
+<a class="index-entry-id" id="index-font-1"></a>
+<a class="index-entry-id" id="index-color-1"></a>
+<a class="index-entry-id" id="index-interface-5"></a>
+<a class="index-entry-id" id="index-custom-9"></a>
+<a class="index-entry-id" id="index-configure-9"></a>
 <p>The following example applies a bit of customization and demonstrates
 how to change quick-access hints faces.
 </p>
 <div class="example lisp">
-<pre class="lisp">(setq company-show-quick-access t)
+<pre class="lisp-preformatted">(setq company-show-quick-access t)
 
 (custom-set-faces
  '(company-tooltip-quick-access ((t (:foreground &quot;pink1&quot;))))
@@ -637,26 +642,26 @@ how to change quick-access hints faces.
    ((t (:foreground &quot;pink1&quot; :slant italic)))))
 </pre></div>
 
-<img src="./images/large/tooltip-qa-faces-light.png" alt="./images/large/tooltip-qa-faces-light">
+<img class="image" src="./images/large/tooltip-qa-faces-light.png" alt="./images/large/tooltip-qa-faces-light">
 
 </div>
 </div>
-<div class="footnote">
+<div class="footnotes-segment">
 <hr>
 <h4 class="footnotes-heading">Footnotes</h4>
 
-<h5><a id="FOOT3" href="#DOCF3">(3)</a></h5>
-<p><acronym>SVG</acronym> images support has to be enabled in Emacs for
+<h5 class="footnote-body-heading"><a id="FOOT3" href="#DOCF3">(3)</a></h5>
+<p><abbr class="acronym">SVG</abbr> images support has to be enabled in Emacs for
 these icons set to be used.  The supported images types can be checked
-with <code>C-h v image-types</code>.  Before compiling Emacs, make sure
-&lsquo;<samp>librsvg</samp>&rsquo; is installed on your system.</p>
-<h5><a id="FOOT4" href="#DOCF4">(4)</a></h5>
+with <code class="code">C-h v image-types</code>.  Before compiling Emacs, make sure
+&lsquo;<samp class="samp">librsvg</samp>&rsquo; is installed on your system.</p>
+<h5 class="footnote-body-heading"><a id="FOOT4" href="#DOCF4">(4)</a></h5>
 <p>The candidates retrieved according to
-<code>non-prefix</code> matches (see <a href="Overview.html#Terminology">Terminology</a>) may be shown in full
+<code class="code">non-prefix</code> matches (see <a class="pxref" href="Overview.html#Terminology">Terminology</a>) may be shown in full
 after point.</p>
 </div>
 <hr>
-<div class="header">
+<div class="nav-panel">
 <p>
 Next: <a href="Backends.html#Backends" accesskey="n" rel="next">Backends</a>, Previous: <a href="Customization.html#Customization" accesskey="p" rel="prev">Customization</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>

--- a/manual/Getting-Started.html
+++ b/manual/Getting-Started.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
-<!-- Created by GNU Texinfo 6.8, https://www.gnu.org/software/texinfo/ -->
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <!-- This user manual is for Company version 0.9.14snapshot
-(12 August 2022).
+(16 April 2023).
 
-Copyright (C) 2021-2022  Free Software Foundation, Inc.
+Copyright © 2021-2023  Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -27,21 +27,13 @@ any later version published by the Free Software Foundation. -->
 <link href="Overview.html#Overview" rel="prev" title="Overview">
 <style type="text/css">
 <!--
-a.copiable-anchor {visibility: hidden; text-decoration: none; line-height: 0em}
-a.summary-letter {text-decoration: none}
-blockquote.indentedblock {margin-right: 0em}
-div.display {margin-left: 3.2em}
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
 div.example {margin-left: 3.2em}
-kbd {font-style: oblique}
-pre.display {font-family: inherit}
-pre.format {font-family: inherit}
-pre.menu-comment {font-family: serif}
-pre.menu-preformatted {font-family: serif}
-span.nolinebreak {white-space: nowrap}
-span.roman {font-family: initial; font-weight: normal}
-span.sansserif {font-family: sans-serif; font-weight: normal}
-span:hover a.copiable-anchor {visibility: visible}
-ul.no-bullet {list-style: none}
+kbd.kbd {font-style: oblique}
+kbd.key {font-style: normal}
+span.w-nolinebreak-text {white-space: nowrap}
+span:hover a.copiable-link {visibility: visible}
+ul.mark-bullet {list-style-type: disc}
 -->
 </style>
 <link rel="stylesheet" type="text/css" href="https://company-mode.github.io/stylesheets/stylesheet.css">
@@ -50,203 +42,203 @@ ul.no-bullet {list-style: none}
 </head>
 
 <body lang="en">
-<div class="inner manual"><div class="chapter" id="Getting-Started">
-<div class="header">
+<div class="inner manual"><div class="chapter-level-extent" id="Getting-Started">
+<div class="nav-panel">
 <p>
 Next: <a href="Customization.html#Customization" accesskey="n" rel="next">Customization</a>, Previous: <a href="Overview.html#Overview" accesskey="p" rel="prev">Overview</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>
 <hr>
-<span id="Getting-Started-1"></span><h2 class="chapter">Getting Started</h2>
+<h2 class="chapter" id="Getting-Started-1">Getting Started</h2>
 
 <p>This chapter provides basic instructions for Company setup and usage.
 </p>
 
 <hr>
-<div class="section" id="Installation">
-<span id="Installation-1"></span><h3 class="section">Installation</h3>
+<div class="section-level-extent" id="Installation">
+<h3 class="section" id="Installation-1">Installation</h3>
 
-<span id="index-distribution"></span>
-<span id="index-package"></span>
-<span id="index-install"></span>
+<a class="index-entry-id" id="index-distribution"></a>
+<a class="index-entry-id" id="index-package"></a>
+<a class="index-entry-id" id="index-install"></a>
 <p>Company package is distributed via commonly used package archives in a
 form of both stable and development releases.  To install Company,
-type <kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">package-install</span>&nbsp;<span class="key">RET</span>&nbsp;company&nbsp;<span class="key">RET</span></kbd><!-- /@w -->.
+type <kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">package-install</span>&nbsp;<kbd class="key">RET</kbd>&nbsp;company&nbsp;<kbd class="key">RET</kbd></kbd><!-- /@w -->.
 </p>
 <p>For more details on Emacs package archives, see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Packages.html#Packages">(emacs)Packages</a>.
 </p>
 <hr>
 </div>
-<div class="section" id="Initial-Setup">
-<span id="Initial-Setup-1"></span><h3 class="section">Initial Setup</h3>
+<div class="section-level-extent" id="Initial-Setup">
+<h3 class="section" id="Initial-Setup-1">Initial Setup</h3>
 
-<span id="index-quick-start"></span>
-<span id="index-intro"></span>
-<span id="index-minor_002dmode"></span>
-<span id="index-company_002dmode"></span>
-<span id="index-company_002dmode-1"></span>
-<p>The package Company provides a minor mode <em>company-mode</em>.
+<a class="index-entry-id" id="index-quick-start"></a>
+<a class="index-entry-id" id="index-intro"></a>
+<a class="index-entry-id" id="index-minor_002dmode"></a>
+<a class="index-entry-id" id="index-company_002dmode"></a>
+<a class="index-entry-id" id="index-company_002dmode-1"></a>
+<p>The package Company provides a minor mode <em class="dfn">company-mode</em>.
 </p>
-<span id="index-enable"></span>
-<span id="index-activate"></span>
-<span id="index-manual"></span>
-<p>To activate the <em>company-mode</em>, execute the command <kbd>M-x
+<a class="index-entry-id" id="index-enable"></a>
+<a class="index-entry-id" id="index-activate"></a>
+<a class="index-entry-id" id="index-manual"></a>
+<p>To activate the <em class="emph">company-mode</em>, execute the command <kbd class="kbd">M-x
 company-mode</kbd> that toggles the mode on and off.  When it is switched
 on, the mode line (see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Mode-line.html#Mode-line">(emacs)Mode line</a>) should indicate its
-presence with an indicator &lsquo;<samp>company</samp>&rsquo;.
+presence with an indicator &lsquo;<samp class="samp">company</samp>&rsquo;.
 </p>
-<span id="index-auto_002dstart"></span>
-<p>After <em>company-mode</em> had been enabled, the package auto-starts
+<a class="index-entry-id" id="index-auto_002dstart"></a>
+<p>After <em class="emph">company-mode</em> had been enabled, the package auto-starts
 suggesting completion candidates.  The candidates are retrieved and
 shown according to the typed characters and the default (until a user
 specifies otherwise) configurations.
 </p>
-<span id="index-global_002dcompany_002dmode"></span>
+<a class="index-entry-id" id="index-global_002dcompany_002dmode"></a>
 <p>To have Company always enabled for the following sessions, add the
-line <code><span class="nolinebreak">(global-company-mode)</span></code><!-- /@w --> to the Emacs configuration file
-(see&nbsp;<a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html#Init-File">(emacs)Init&nbsp;File</a>)<!-- /@w -->.
+line <code class="code"><span class="w-nolinebreak-text">(global-company-mode)</span></code><!-- /@w --> to the Emacs configuration file
+(see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html#Init-File">(emacs)Init File</a>).
 </p>
 <hr>
 </div>
-<div class="section" id="Usage-Basics">
-<span id="Usage-Basics-1"></span><h3 class="section">Usage Basics</h3>
+<div class="section-level-extent" id="Usage-Basics">
+<h3 class="section" id="Usage-Basics-1">Usage Basics</h3>
 
-<span id="index-usage"></span>
-<span id="index-basics"></span>
-<p>By default &mdash; having <em>company-mode</em> enabled (see <a href="#Initial-Setup">Initial Setup</a>) &mdash; a tooltip with completion candidates is shown when a user
+<a class="index-entry-id" id="index-usage"></a>
+<a class="index-entry-id" id="index-basics"></a>
+<p>By default &mdash; having <em class="emph">company-mode</em> enabled (see <a class="pxref" href="#Initial-Setup">Initial Setup</a>) &mdash; a tooltip with completion candidates is shown when a user
 types in a few characters.
 </p>
-<span id="index-manual-1"></span>
-<span id="index-company_002dcomplete"></span>
-<p>To initiate completion manually, use the command <kbd>M-x
+<a class="index-entry-id" id="index-manual-1"></a>
+<a class="index-entry-id" id="index-company_002dcomplete"></a>
+<p>To initiate completion manually, use the command <kbd class="kbd">M-x
 company-complete</kbd>.
 </p>
-<span id="index-select"></span>
-<span id="index-navigate"></span>
-<span id="index-complete-1"></span>
-<span id="index-completion-1"></span>
-<span id="index-candidate-1"></span>
-<span id="index-C_002dn"></span>
-<span id="index-C_002dp"></span>
+<a class="index-entry-id" id="index-select"></a>
+<a class="index-entry-id" id="index-navigate"></a>
+<a class="index-entry-id" id="index-complete-1"></a>
+<a class="index-entry-id" id="index-completion-1"></a>
+<a class="index-entry-id" id="index-candidate-1"></a>
+<a class="index-entry-id" id="index-C_002dn"></a>
+<a class="index-entry-id" id="index-C_002dp"></a>
 <p>To select next or previous of the shown completion candidates, use
-respectively key bindings <kbd>C-n</kbd> and <kbd>C-p</kbd>, then do one of the
+respectively key bindings <kbd class="kbd">C-n</kbd> and <kbd class="kbd">C-p</kbd>, then do one of the
 following:
 </p>
-<ul>
-<li> <span id="index-complete-2"></span>
-<span id="index-completion-2"></span>
-<span id="index-candidate-2"></span>
-<span id="index-RET"></span>
-Hit <tt class="key">RET</tt> to choose a selected candidate for completion.
+<ul class="itemize mark-bullet">
+<li><a class="index-entry-id" id="index-complete-2"></a>
+<a class="index-entry-id" id="index-completion-2"></a>
+<a class="index-entry-id" id="index-candidate-2"></a>
+<a class="index-entry-id" id="index-RET"></a>
+Hit <kbd class="key">RET</kbd> to choose a selected candidate for completion.
 
-</li><li> <span id="index-common-part"></span>
-<span id="index-complete-3"></span>
-<span id="index-completion-3"></span>
-<span id="index-TAB-1"></span>
-Hit <tt class="key">TAB</tt> to complete with the <em>common part</em>: characters
+</li><li><a class="index-entry-id" id="index-common-part"></a>
+<a class="index-entry-id" id="index-complete-3"></a>
+<a class="index-entry-id" id="index-completion-3"></a>
+<a class="index-entry-id" id="index-TAB-1"></a>
+Hit <kbd class="key">TAB</kbd> to complete with the <em class="dfn">common part</em>: characters
 present at the beginning of all the candidates.
 
-</li><li> <span id="index-abort"></span>
-<span id="index-quit"></span>
-<span id="index-finish"></span>
-<span id="index-stop"></span>
-<span id="index-cancel"></span>
-<span id="index-C_002dg"></span>
-Hit <kbd>C-g</kbd> to stop activity of Company.
+</li><li><a class="index-entry-id" id="index-abort"></a>
+<a class="index-entry-id" id="index-quit"></a>
+<a class="index-entry-id" id="index-finish"></a>
+<a class="index-entry-id" id="index-stop"></a>
+<a class="index-entry-id" id="index-cancel"></a>
+<a class="index-entry-id" id="index-C_002dg"></a>
+Hit <kbd class="kbd">C-g</kbd> to stop activity of Company.
 </li></ul>
 
 <hr>
 </div>
-<div class="section" id="Commands">
-<span id="Commands-1"></span><h3 class="section">Commands</h3>
+<div class="section-level-extent" id="Commands">
+<h3 class="section" id="Commands-1">Commands</h3>
 
 <p>Under the hood, mentioned in the previous section keys are bound to
 the commands of the out-of-the-box Company.
 </p>
-<dl compact="compact">
-<dt id='index-C_002dn-1'><span><kbd>C-n</kbd><a href='#index-C_002dn-1' class='copiable-anchor'> &para;</a></span></dt>
-<dt><span><kbd>M-n</kbd></span></dt>
-<dd><span id="index-select-1"></span>
-<span id="index-company_002dselect_002dnext_002dor_002dabort"></span>
-<span id="index-company_002dselect_002dnext"></span>
-<p>Select the next candidate (<code>company-select-next-or-abort</code>,
-<code><span class="nolinebreak">company-select-next</span></code><!-- /@w -->).
+<dl class="table">
+<dt id='index-C_002dn-1'><span><kbd class="kbd">C-n</kbd><a class="copiable-link" href='#index-C_002dn-1'> &para;</a></span></dt>
+<dt><kbd class="kbd">M-n</kbd></dt>
+<dd><a class="index-entry-id" id="index-select-1"></a>
+<a class="index-entry-id" id="index-company_002dselect_002dnext_002dor_002dabort"></a>
+<a class="index-entry-id" id="index-company_002dselect_002dnext"></a>
+<p>Select the next candidate (<code class="code">company-select-next-or-abort</code>,
+<code class="code"><span class="w-nolinebreak-text">company-select-next</span></code><!-- /@w -->).
 </p>
 </dd>
-<dt id='index-C_002dp-1'><span><kbd>C-p</kbd><a href='#index-C_002dp-1' class='copiable-anchor'> &para;</a></span></dt>
-<dt><span><kbd>M-p</kbd></span></dt>
-<dd><span id="index-select-2"></span>
-<span id="index-company_002dselect_002dprevious_002dor_002dabort"></span>
-<span id="index-company_002dselect_002dprevious"></span>
+<dt id='index-C_002dp-1'><span><kbd class="kbd">C-p</kbd><a class="copiable-link" href='#index-C_002dp-1'> &para;</a></span></dt>
+<dt><kbd class="kbd">M-p</kbd></dt>
+<dd><a class="index-entry-id" id="index-select-2"></a>
+<a class="index-entry-id" id="index-company_002dselect_002dprevious_002dor_002dabort"></a>
+<a class="index-entry-id" id="index-company_002dselect_002dprevious"></a>
 <p>Select the previous candidate
-(<code>company-select-previous-or-abort</code>,
-<code><span class="nolinebreak">company-select-previous</span></code><!-- /@w -->).
+(<code class="code">company-select-previous-or-abort</code>,
+<code class="code"><span class="w-nolinebreak-text">company-select-previous</span></code><!-- /@w -->).
 </p>
 </dd>
-<dt id='index-RET-1'><span><kbd>RET</kbd><a href='#index-RET-1' class='copiable-anchor'> &para;</a></span></dt>
-<dt><span><kbd>&lt;return&gt;</kbd></span></dt>
-<dd><span id="index-complete-4"></span>
-<span id="index-company_002dcomplete_002dselection"></span>
-<p>Insert the selected candidate (<code>company-complete-selection</code>).
+<dt id='index-RET-1'><span><kbd class="kbd">RET</kbd><a class="copiable-link" href='#index-RET-1'> &para;</a></span></dt>
+<dt><kbd class="kbd">&lt;return&gt;</kbd></dt>
+<dd><a class="index-entry-id" id="index-complete-4"></a>
+<a class="index-entry-id" id="index-company_002dcomplete_002dselection"></a>
+<p>Insert the selected candidate (<code class="code">company-complete-selection</code>).
 </p>
 </dd>
-<dt id='index-TAB-2'><span><kbd>TAB</kbd><a href='#index-TAB-2' class='copiable-anchor'> &para;</a></span></dt>
-<dt><span><kbd>&lt;tab&gt;</kbd></span></dt>
-<dd><span id="index-common-part-1"></span>
-<span id="index-company_002dcomplete_002dcommon"></span>
+<dt id='index-TAB-2'><span><kbd class="kbd">TAB</kbd><a class="copiable-link" href='#index-TAB-2'> &para;</a></span></dt>
+<dt><kbd class="kbd">&lt;tab&gt;</kbd></dt>
+<dd><a class="index-entry-id" id="index-common-part-1"></a>
+<a class="index-entry-id" id="index-company_002dcomplete_002dcommon"></a>
 <p>Insert the common part of all the candidates
-(<code>company-complete-common</code>).
+(<code class="code">company-complete-common</code>).
 </p>
 </dd>
-<dt id='index-C_002dg-1'><span><kbd>C-g</kbd><a href='#index-C_002dg-1' class='copiable-anchor'> &para;</a></span></dt>
-<dt><span><kbd>&lt;ESC ESC ESC&gt;</kbd></span></dt>
-<dd><span id="index-abort-1"></span>
-<span id="index-quit-1"></span>
-<span id="index-finish-1"></span>
-<span id="index-stop-1"></span>
-<span id="index-cancel-1"></span>
-<span id="index-company_002dabort"></span>
-<p>Cancel <em>company-mode</em> activity (<code>company-abort</code>).
+<dt id='index-C_002dg-1'><span><kbd class="kbd">C-g</kbd><a class="copiable-link" href='#index-C_002dg-1'> &para;</a></span></dt>
+<dt><kbd class="kbd">&lt;ESC ESC ESC&gt;</kbd></dt>
+<dd><a class="index-entry-id" id="index-abort-1"></a>
+<a class="index-entry-id" id="index-quit-1"></a>
+<a class="index-entry-id" id="index-finish-1"></a>
+<a class="index-entry-id" id="index-stop-1"></a>
+<a class="index-entry-id" id="index-cancel-1"></a>
+<a class="index-entry-id" id="index-company_002dabort"></a>
+<p>Cancel <em class="emph">company-mode</em> activity (<code class="code">company-abort</code>).
 </p>
 </dd>
-<dt id='index-C_002dh'><span><kbd>C-h</kbd><a href='#index-C_002dh' class='copiable-anchor'> &para;</a></span></dt>
-<dt><span><kbd>&lt;F1&gt;</kbd></span></dt>
-<dd><span id="index-doc"></span>
-<span id="index-company_002dshow_002ddoc_002dbuffer"></span>
+<dt id='index-C_002dh'><span><kbd class="kbd">C-h</kbd><a class="copiable-link" href='#index-C_002dh'> &para;</a></span></dt>
+<dt><kbd class="kbd">&lt;F1&gt;</kbd></dt>
+<dd><a class="index-entry-id" id="index-doc"></a>
+<a class="index-entry-id" id="index-company_002dshow_002ddoc_002dbuffer"></a>
 <p>Display a buffer with the documentation for the selected candidate
-(<code><span class="nolinebreak">company-show-doc-buffer</span></code><!-- /@w -->).  With a prefix argument
-(<kbd>C-u C-h</kbd>, <kbd>C-u <span class="key">F1</span></kbd>), this command toggles between
+(<code class="code"><span class="w-nolinebreak-text">company-show-doc-buffer</span></code><!-- /@w -->).  With a prefix argument
+(<kbd class="kbd">C-u C-h</kbd>, <kbd class="kbd">C-u <kbd class="key">F1</kbd></kbd>), this command toggles between
 temporary showing the documentation and keeping the documentation
 buffer up-to-date whenever the selection changes.
 </p>
 </dd>
-<dt id='index-C_002dw'><span><kbd>C-w</kbd><a href='#index-C_002dw' class='copiable-anchor'> &para;</a></span></dt>
-<dd><span id="index-definition"></span>
-<span id="index-location"></span>
-<span id="index-company_002dshow_002dlocation"></span>
+<dt id='index-C_002dw'><span><kbd class="kbd">C-w</kbd><a class="copiable-link" href='#index-C_002dw'> &para;</a></span></dt>
+<dd><a class="index-entry-id" id="index-definition"></a>
+<a class="index-entry-id" id="index-location"></a>
+<a class="index-entry-id" id="index-company_002dshow_002dlocation"></a>
 <p>Display a buffer with the definition of the selected candidate
-(<code><span class="nolinebreak">company-show-location</span></code><!-- /@w -->).
+(<code class="code"><span class="w-nolinebreak-text">company-show-location</span></code><!-- /@w -->).
 </p>
 </dd>
 </dl>
 
 <p>The full list of the default key bindings is stored in the variables
-<code>company-active-map</code> and <code>company-search-map</code> <a id="DOCF2" href="#FOOT2"><sup>2</sup></a>.
+<code class="code">company-active-map</code> and <code class="code">company-search-map</code> <a class="footnote" id="DOCF2" href="#FOOT2"><sup>2</sup></a>.
 </p>
 <p>Moreover, Company is bundled with a number of convenience commands
 that do not have default key bindings defined.  The following examples
 illustrate how to assign key bindings to such commands.
 </p>
 <div class="example lisp">
-<pre class="lisp">(global-set-key (kbd &quot;&lt;tab&gt;&quot;) #'company-indent-or-complete-common)
+<pre class="lisp-preformatted">(global-set-key (kbd &quot;&lt;tab&gt;&quot;) #'company-indent-or-complete-common)
 </pre></div>
 
 <div class="example lisp">
-<pre class="lisp">(with-eval-after-load 'company
+<pre class="lisp-preformatted">(with-eval-after-load 'company
   (define-key company-active-map (kbd &quot;M-/&quot;) #'company-complete))
 </pre></div>
 
 <div class="example lisp">
-<pre class="lisp">(with-eval-after-load 'company
+<pre class="lisp-preformatted">(with-eval-after-load 'company
   (define-key company-active-map
               (kbd &quot;TAB&quot;)
               #'company-complete-common-or-cycle)
@@ -261,24 +253,24 @@ illustrate how to assign key bindings to such commands.
 a command can be unbound from a key.  For instance:
 </p>
 <div class="example lisp">
-<pre class="lisp">(with-eval-after-load 'company
+<pre class="lisp-preformatted">(with-eval-after-load 'company
   (define-key company-active-map (kbd &quot;M-.&quot;) #'company-show-location)
   (define-key company-active-map (kbd &quot;RET&quot;) nil))
 </pre></div>
 
 </div>
 </div>
-<div class="footnote">
+<div class="footnotes-segment">
 <hr>
 <h4 class="footnotes-heading">Footnotes</h4>
 
-<h5><a id="FOOT2" href="#DOCF2">(2)</a></h5>
+<h5 class="footnote-body-heading"><a id="FOOT2" href="#DOCF2">(2)</a></h5>
 <p>For
 a more user-friendly output of the pre-defined key bindings, utilize
-<kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">describe-keymap</span>&nbsp;<span class="key">RET</span>&nbsp;<span class="nolinebreak">company-active-map</span></kbd><!-- /@w --> or <kbd><span class="nolinebreak">C-h</span>&nbsp;f&nbsp;<span class="key">RET</span>&nbsp;<span class="nolinebreak">company-mode</span></kbd><!-- /@w -->.</p>
+<kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">describe-keymap</span>&nbsp;<kbd class="key">RET</kbd>&nbsp;<span class="w-nolinebreak-text">company-active-map</span></kbd><!-- /@w --> or <kbd class="kbd"><span class="w-nolinebreak-text">C-h</span>&nbsp;f&nbsp;<kbd class="key">RET</kbd>&nbsp;<span class="w-nolinebreak-text">company-mode</span></kbd><!-- /@w -->.</p>
 </div>
 <hr>
-<div class="header">
+<div class="nav-panel">
 <p>
 Next: <a href="Customization.html#Customization" accesskey="n" rel="next">Customization</a>, Previous: <a href="Overview.html#Overview" accesskey="p" rel="prev">Overview</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>

--- a/manual/Overview.html
+++ b/manual/Overview.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
-<!-- Created by GNU Texinfo 6.8, https://www.gnu.org/software/texinfo/ -->
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <!-- This user manual is for Company version 0.9.14snapshot
-(12 August 2022).
+(16 April 2023).
 
-Copyright (C) 2021-2022  Free Software Foundation, Inc.
+Copyright © 2021-2023  Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -27,21 +27,9 @@ any later version published by the Free Software Foundation. -->
 <link href="index.html" rel="prev" title="Top">
 <style type="text/css">
 <!--
-a.copiable-anchor {visibility: hidden; text-decoration: none; line-height: 0em}
-a.summary-letter {text-decoration: none}
-blockquote.indentedblock {margin-right: 0em}
-div.display {margin-left: 3.2em}
 div.example {margin-left: 3.2em}
-kbd {font-style: oblique}
-pre.display {font-family: inherit}
-pre.format {font-family: inherit}
-pre.menu-comment {font-family: serif}
-pre.menu-preformatted {font-family: serif}
-span.nolinebreak {white-space: nowrap}
-span.roman {font-family: initial; font-weight: normal}
-span.sansserif {font-family: sans-serif; font-weight: normal}
-span:hover a.copiable-anchor {visibility: visible}
-ul.no-bullet {list-style: none}
+kbd.key {font-style: normal}
+span.w-nolinebreak-text {white-space: nowrap}
 -->
 </style>
 <link rel="stylesheet" type="text/css" href="https://company-mode.github.io/stylesheets/stylesheet.css">
@@ -50,15 +38,15 @@ ul.no-bullet {list-style: none}
 </head>
 
 <body lang="en">
-<div class="inner manual"><div class="chapter" id="Overview">
-<div class="header">
+<div class="inner manual"><div class="chapter-level-extent" id="Overview">
+<div class="nav-panel">
 <p>
 Next: <a href="Getting-Started.html#Getting-Started" accesskey="n" rel="next">Getting Started</a>, Previous: <a href="index.html" accesskey="p" rel="prev">Company</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>
 <hr>
-<span id="Overview-1"></span><h2 class="chapter">Overview</h2>
+<h2 class="chapter" id="Overview-1">Overview</h2>
 
-<p><em>Company</em> is a modular text completion framework for GNU Emacs.
+<p><em class="dfn">Company</em> is a modular text completion framework for GNU Emacs.
 </p>
 <p>In other words, it is a package for retrieving, manipulating, and
 displaying text completion candidates. It aims to assist developers,
@@ -66,95 +54,95 @@ writers, and scientists during code and text writing.
 </p>
 
 <hr>
-<div class="section" id="Terminology">
-<span id="Terminology-1"></span><h3 class="section">Terminology</h3>
+<div class="section-level-extent" id="Terminology">
+<h3 class="section" id="Terminology-1">Terminology</h3>
 
-<span id="index-completion"></span>
-<span id="index-complete"></span>
-<p><em>Completion</em> is an act of intelligibly guessing possible variants
-of words based on already typed characters.  To <em>complete</em> a word
+<a class="index-entry-id" id="index-completion"></a>
+<a class="index-entry-id" id="index-complete"></a>
+<p><em class="dfn">Completion</em> is an act of intelligibly guessing possible variants
+of words based on already typed characters.  To <em class="dfn">complete</em> a word
 means to insert a correctly guessed variant into the buffer.
 </p>
-<span id="index-candidate"></span>
-<span id="index-prefix-matches"></span>
-<span id="index-non_002dprefix-matches"></span>
-<p>Consequently, the <em>candidates</em> are the aforementioned guessed
+<a class="index-entry-id" id="index-candidate"></a>
+<a class="index-entry-id" id="index-prefix-matches"></a>
+<a class="index-entry-id" id="index-non_002dprefix-matches"></a>
+<p>Consequently, the <em class="dfn">candidates</em> are the aforementioned guessed
 variants of words.  Each of the candidates has the potential to be
 chosen for successful completion.  And each of the candidates contains
 the initially typed characters: either only at the beginning
-(so-called <em>prefix matches</em>), or also inside (<em>non-prefix
-matches</em>) of a candidate <a id="DOCF1" href="#FOOT1"><sup>1</sup></a>.
+(so-called <em class="dfn">prefix matches</em>), or also inside (<em class="dfn">non-prefix
+matches</em>) of a candidate <a class="footnote" id="DOCF1" href="#FOOT1"><sup>1</sup></a>.
 </p>
-<p>The package&rsquo;s name <em>Company</em> is based on the combination of the
-two words: &lsquo;<samp>Complete</samp>&rsquo; and &lsquo;<samp>Anything</samp>&rsquo;.  These words reflect
+<p>The package&rsquo;s name <em class="dfn">Company</em> is based on the combination of the
+two words: &lsquo;<samp class="samp">Complete</samp>&rsquo; and &lsquo;<samp class="samp">Anything</samp>&rsquo;.  These words reflect
 the package&rsquo;s commitment to handling completion candidates and its
 extensible nature allowing it to cover a wide range of usage
 scenarios.
 </p>
 <hr>
 </div>
-<div class="section" id="Structure">
-<span id="Structure-1"></span><h3 class="section">Structure</h3>
+<div class="section-level-extent" id="Structure">
+<h3 class="section" id="Structure-1">Structure</h3>
 
-<span id="index-module"></span>
-<span id="index-pluggable"></span>
-<span id="index-extensible"></span>
-<span id="index-backend"></span>
-<span id="index-frontend"></span>
+<a class="index-entry-id" id="index-module"></a>
+<a class="index-entry-id" id="index-pluggable"></a>
+<a class="index-entry-id" id="index-extensible"></a>
+<a class="index-entry-id" id="index-backend"></a>
+<a class="index-entry-id" id="index-frontend"></a>
 <p>The Company is easily extensible because its significant building
-blocks are pluggable modules: backends (see <a href="Backends.html#Backends">Backends</a>) and
-frontends (see <a href="Frontends.html#Frontends">Frontends</a>).
+blocks are pluggable modules: backends (see <a class="pxref" href="Backends.html#Backends">Backends</a>) and
+frontends (see <a class="pxref" href="Frontends.html#Frontends">Frontends</a>).
 </p>
-<span id="index-backend-1"></span>
-<span id="index-frontend-1"></span>
-<span id="index-module-1"></span>
-<span id="index-third_002dparty"></span>
-<p>The <em>backends</em> are responsible for retrieving completion
-candidates; which are then outputted by the <em>frontends</em>.  For an
+<a class="index-entry-id" id="index-backend-1"></a>
+<a class="index-entry-id" id="index-frontend-1"></a>
+<a class="index-entry-id" id="index-module-1"></a>
+<a class="index-entry-id" id="index-third_002dparty"></a>
+<p>The <em class="dfn">backends</em> are responsible for retrieving completion
+candidates; which are then outputted by the <em class="dfn">frontends</em>.  For an
 easy and quick initial setup, Company is supplied with the
 preconfigured sets of the backends and frontends.  The default
 behavior of the modules can be adjusted per particular needs, goals,
 and preferences.  It is also typical to utilize backends from a
 variety of
-<a href="https://github.com/company-mode/company-mode/wiki/Third-Party-Packages">third-party libraries</a>, developed to be pluggable with Company.
+<a class="uref" href="https://github.com/company-mode/company-mode/wiki/Third-Party-Packages">third-party libraries</a>, developed to be pluggable with Company.
 </p>
 <p>But Company consists not only of the backends and frontends.
 </p>
 <p>A core of the package plays the role of a controller, connecting the
 modules, making them work together; and exposing configurations and
 commands for a user to operate with.  For more details,
-<a href="Customization.html#Customization">Customization</a> and <a href="Getting-Started.html#Commands">Commands</a>.
+<a class="ref" href="Customization.html#Customization">Customization</a> and <a class="ref" href="Getting-Started.html#Commands">Commands</a>.
 </p>
-<span id="index-TAB"></span>
-<span id="index-company_002dtng"></span>
-<span id="index-Tab-and-Go"></span>
-<span id="index-company_002dtng_002dfrontend"></span>
-<span id="index-company_002dtng_002dmode"></span>
+<a class="index-entry-id" id="index-TAB"></a>
+<a class="index-entry-id" id="index-company_002dtng"></a>
+<a class="index-entry-id" id="index-Tab-and-Go"></a>
+<a class="index-entry-id" id="index-company_002dtng_002dfrontend"></a>
+<a class="index-entry-id" id="index-company_002dtng_002dmode"></a>
 <p>Also, Company is bundled with an alternative workflow configuration
-<em>company-tng</em> &mdash; defining <code>company-tng-frontend</code>,
-<code>company-tng-mode</code>, and <code><span class="nolinebreak">company-tng-map</span></code><!-- /@w --> &mdash; that
-allows performing completion with just <tt class="key">TAB</tt>.  To enable this
-configuration, add the following line to the Emacs initialization
-file (see&nbsp;<a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html#Init-File">(emacs)Init&nbsp;File</a>)<!-- /@w -->:
+<em class="dfn">company-tng</em> &mdash; defining <code class="code">company-tng-frontend</code>,
+<code class="code">company-tng-mode</code>, and <code class="code"><span class="w-nolinebreak-text">company-tng-map</span></code><!-- /@w --> &mdash; that
+allows performing completion with just <kbd class="key">TAB</kbd>.  To enable this
+configuration, add the following line to the Emacs initialization file
+(see <a data-manual="emacs" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html#Init-File">(emacs)Init File</a>):
 </p>
 <div class="example lisp">
-<pre class="lisp">(add-hook 'after-init-hook 'company-tng-mode)
+<pre class="lisp-preformatted">(add-hook 'after-init-hook 'company-tng-mode)
 </pre></div>
 
 </div>
 </div>
-<div class="footnote">
+<div class="footnotes-segment">
 <hr>
 <h4 class="footnotes-heading">Footnotes</h4>
 
-<h5><a id="FOOT1" href="#DOCF1">(1)</a></h5>
+<h5 class="footnote-body-heading"><a id="FOOT1" href="#DOCF1">(1)</a></h5>
 <p>A good starting point to learn
 about types of matches is to play with the Emacs&rsquo;s user option
-<code>completion-styles</code>.  For illustrations on how Company visualizes
-the matches, see <a href="Frontends.html#Frontends">Frontends</a>.</p>
+<code class="code">completion-styles</code>.  For illustrations on how Company visualizes
+the matches, see <a class="pxref" href="Frontends.html#Frontends">Frontends</a>.</p>
 </div>
 <hr>
-<div class="header">
+<div class="nav-panel">
 <p>
 Next: <a href="Getting-Started.html#Getting-Started" accesskey="n" rel="next">Getting Started</a>, Previous: <a href="index.html" accesskey="p" rel="prev">Company</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>

--- a/manual/Troubleshooting.html
+++ b/manual/Troubleshooting.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
-<!-- Created by GNU Texinfo 6.8, https://www.gnu.org/software/texinfo/ -->
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <!-- This user manual is for Company version 0.9.14snapshot
-(12 August 2022).
+(16 April 2023).
 
-Copyright (C) 2021-2022  Free Software Foundation, Inc.
+Copyright © 2021-2023  Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -26,21 +26,10 @@ any later version published by the Free Software Foundation. -->
 <link href="Backends.html#Backends" rel="prev" title="Backends">
 <style type="text/css">
 <!--
-a.copiable-anchor {visibility: hidden; text-decoration: none; line-height: 0em}
-a.summary-letter {text-decoration: none}
-blockquote.indentedblock {margin-right: 0em}
-div.display {margin-left: 3.2em}
-div.example {margin-left: 3.2em}
-kbd {font-style: oblique}
-pre.display {font-family: inherit}
-pre.format {font-family: inherit}
-pre.menu-comment {font-family: serif}
-pre.menu-preformatted {font-family: serif}
-span.nolinebreak {white-space: nowrap}
-span.roman {font-family: initial; font-weight: normal}
-span.sansserif {font-family: sans-serif; font-weight: normal}
-span:hover a.copiable-anchor {visibility: visible}
-ul.no-bullet {list-style: none}
+kbd.kbd {font-style: oblique}
+kbd.key {font-style: normal}
+span.w-nolinebreak-text {white-space: nowrap}
+ul.mark-bullet {list-style-type: disc}
 -->
 </style>
 <link rel="stylesheet" type="text/css" href="https://company-mode.github.io/stylesheets/stylesheet.css">
@@ -49,68 +38,68 @@ ul.no-bullet {list-style: none}
 </head>
 
 <body lang="en">
-<div class="inner manual"><div class="chapter" id="Troubleshooting">
-<div class="header">
+<div class="inner manual"><div class="chapter-level-extent" id="Troubleshooting">
+<div class="nav-panel">
 <p>
 Previous: <a href="Backends.html#Backends" accesskey="p" rel="prev">Backends</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>
 <hr>
-<span id="Troubleshooting-1"></span><h2 class="chapter">Troubleshooting</h2>
+<h2 class="chapter" id="Troubleshooting-1">Troubleshooting</h2>
 
-<span id="index-troubleshoot"></span>
-<span id="index-bug"></span>
-<span id="index-issue"></span>
-<span id="index-error"></span>
-<span id="index-company_002ddiag-1"></span>
+<a class="index-entry-id" id="index-troubleshoot"></a>
+<a class="index-entry-id" id="index-bug"></a>
+<a class="index-entry-id" id="index-issue"></a>
+<a class="index-entry-id" id="index-error"></a>
+<a class="index-entry-id" id="index-company_002ddiag-1"></a>
 <p>If something goes wrong, the first thing we recommend doing is to
-execute command <kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">company-diag</span></kbd><!-- /@w --> and thoroughly study its
+execute command <kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">company-diag</span></kbd><!-- /@w --> and thoroughly study its
 output.
 </p>
 <p>This command outputs important details about the internal workings of
-Company at the moment of the <kbd>company-diag</kbd> command execution,
+Company at the moment of the <kbd class="kbd">company-diag</kbd> command execution,
 including a responsible backend and a list of completion candidates
 provided by it.
 </p>
-<span id="index-active-backend-1"></span>
-<span id="index-backend-4"></span>
-<p>Based on the value of the &lsquo;<samp>Used backend</samp>&rsquo; in the output of the
-command <kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">company-diag</span></kbd><!-- /@w -->, these possible actions may follow:
+<a class="index-entry-id" id="index-active-backend-1"></a>
+<a class="index-entry-id" id="index-backend-4"></a>
+<p>Based on the value of the &lsquo;<samp class="samp">Used backend</samp>&rsquo; in the output of the
+command <kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">company-diag</span></kbd><!-- /@w -->, these possible actions may follow:
 </p>
-<ul>
-<li> <span id="index-third_002dparty-1"></span>
+<ul class="itemize mark-bullet">
+<li><a class="index-entry-id" id="index-third_002dparty-1"></a>
 If the used backend does not belong to the Company package, report the
 issue to the corresponding third-party package maintainer(s).
 
-</li><li> If the used backend is &lsquo;<samp>company-capf</samp>&rsquo;, then take a look at the
-line starting with &lsquo;<samp>Value of c-a-p-f:</samp>&rsquo;.  The issue could have
+</li><li>If the used backend is &lsquo;<samp class="samp">company-capf</samp>&rsquo;, then take a look at the
+line starting with &lsquo;<samp class="samp">Value of c-a-p-f:</samp>&rsquo;.  The issue could have
 been caused by a function listed there.  To identify to which package
-it belongs, type <kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">find-function</span>&nbsp;<span class="key">RET</span>&nbsp;<span class="nolinebreak">&lt;function-name&gt;</span>&nbsp;<span class="key">RET</span></kbd><!-- /@w -->.
+it belongs, type <kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">find-function</span>&nbsp;<kbd class="key">RET</kbd>&nbsp;<span class="w-nolinebreak-text">&lt;function-name&gt;</span>&nbsp;<kbd class="key">RET</kbd></kbd><!-- /@w -->.
 </li></ul>
 
-<span id="index-issue-tracker"></span>
-<span id="index-bug-1"></span>
-<span id="index-error-1"></span>
+<a class="index-entry-id" id="index-issue-tracker"></a>
+<a class="index-entry-id" id="index-bug-1"></a>
+<a class="index-entry-id" id="index-error-1"></a>
 <p>If the aforementioned steps didn&rsquo;t help to find the cause of the
 issue, then file a bug report to
-<a href="https://github.com/company-mode/company-mode/issues">the&nbsp;Company&nbsp;Issue&nbsp;Tracker</a><!-- /@w -->, attaching the following information:
+<a class="uref" href="https://github.com/company-mode/company-mode/issues">the&nbsp;Company&nbsp;Issue&nbsp;Tracker</a><!-- /@w -->, attaching the following information:
 </p>
-<ol>
-<li> Output of the <kbd>M-x company-diag</kbd>.
+<ol class="enumerate">
+<li> Output of the <kbd class="kbd">M-x company-diag</kbd>.
 
-</li><li> The exact error message: you can find it in the <samp>*Messages*</samp>
+</li><li> The exact error message: you can find it in the <samp class="file">*Messages*</samp>
 buffer.
 
 </li><li> The steps to reproduce the behavior. Ideally, if you can, starting
-with a bare Emacs session: <code>emacs -Q</code>.
+with a bare Emacs session: <code class="code">emacs -Q</code>.
 
 </li><li> The backtrace of the error, which you can get by running the command:
-<kbd><span class="nolinebreak">M-x</span>&nbsp;<span class="nolinebreak">toggle-debug-on-error</span></kbd><!-- /@w --> before reproducing the error.
+<kbd class="kbd"><span class="w-nolinebreak-text">M-x</span>&nbsp;<span class="w-nolinebreak-text">toggle-debug-on-error</span></kbd><!-- /@w --> before reproducing the error.
 </li></ol>
 
 
 </div>
 <hr>
-<div class="header">
+<div class="nav-panel">
 <p>
 Previous: <a href="Backends.html#Backends" accesskey="p" rel="prev">Backends</a>, Up: <a href="index.html" accesskey="u" rel="up">Company</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>

--- a/manual/index.html
+++ b/manual/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
-<!-- Created by GNU Texinfo 6.8, https://www.gnu.org/software/texinfo/ -->
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <!-- This user manual is for Company version 0.9.14snapshot
-(12 August 2022).
+(16 April 2023).
 
-Copyright (C) 2021-2022  Free Software Foundation, Inc.
+Copyright © 2021-2023  Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -25,21 +25,6 @@ any later version published by the Free Software Foundation. -->
 <link href="Overview.html#Overview" rel="next" title="Overview">
 <style type="text/css">
 <!--
-a.copiable-anchor {visibility: hidden; text-decoration: none; line-height: 0em}
-a.summary-letter {text-decoration: none}
-blockquote.indentedblock {margin-right: 0em}
-div.display {margin-left: 3.2em}
-div.example {margin-left: 3.2em}
-kbd {font-style: oblique}
-pre.display {font-family: inherit}
-pre.format {font-family: inherit}
-pre.menu-comment {font-family: serif}
-pre.menu-preformatted {font-family: serif}
-span.nolinebreak {white-space: nowrap}
-span.roman {font-family: initial; font-weight: normal}
-span.sansserif {font-family: sans-serif; font-weight: normal}
-span:hover a.copiable-anchor {visibility: visible}
-ul.no-bullet {list-style: none}
 -->
 </style>
 <link rel="stylesheet" type="text/css" href="https://company-mode.github.io/stylesheets/stylesheet.css">
@@ -48,18 +33,17 @@ ul.no-bullet {list-style: none}
 </head>
 
 <body lang="en">
-<div class="inner manual"><h1 class="settitle" align="center">Company User Manual</h1>
+<div class="inner manual">
 
 
 
 
-
-<div class="top" id="Top">
-<div class="header">
+<div class="top-level-extent" id="Top">
+<div class="nav-panel">
 <p>
 Next: <a href="Overview.html#Overview" accesskey="n" rel="next">Overview</a> &nbsp; [<a href="#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>
-<span id="Company"></span><h1 class="top">Company</h1>
+<h1 class="top" id="Company">Company</h1>
 
 <p>Company is a modular text completion framework for GNU Emacs.
 </p>
@@ -68,18 +52,18 @@ the package, so that the readers of the manual could competently start
 adapting Company to their needs and preferences.
 </p>
 <p>This user manual is for Company version 0.9.14snapshot
-(12&nbsp;August&nbsp;2022)<!-- /@w -->.
+(16&nbsp;April&nbsp;2023)<!-- /@w -->.
 </p>
-<p>Copyright &copy; 2021-2022  Free Software Foundation, Inc.
+<p>Copyright &copy; 2021-2023  Free Software Foundation, Inc.
 </p>
-<blockquote>
+<blockquote class="quotation">
 <p>Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
 any later version published by the Free Software Foundation.
 </p></blockquote>
 
 
-<div class="Contents_element" id="SEC_Contents">
+<div class="element-contents" id="SEC_Contents">
 <h2 class="contents-heading">Table of Contents</h2>
 
 <div class="contents">
@@ -130,7 +114,7 @@ any later version published by the Free Software Foundation.
 </div>
 </div>
 <hr>
-<div class="header">
+<div class="nav-panel">
 <p>
 Next: <a href="Overview.html#Overview" accesskey="n" rel="next">Overview</a> &nbsp; [<a href="#SEC_Contents" title="Table of contents" rel="contents">Contents</a>]</p>
 </div>


### PR DESCRIPTION
Adds 'company-tooltip-annotation-padding'.

Notable changes introduced by Texinfo 7.0:
- It generates HTML5 doctype.
- `@kbd` now generates `<kbd>` with the `class="kbd"`, which adds `font-style: oblique;`. LGTM.